### PR TITLE
[APPLS-1798] Added command for getting applications and enviroments lists

### DIFF
--- a/drapps/helpers/execution_environments_functions.py
+++ b/drapps/helpers/execution_environments_functions.py
@@ -1,0 +1,32 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import posixpath
+from typing import Any, Dict, List, Optional
+
+from requests import Session
+
+from .handle_dr_response import handle_dr_response
+
+
+def get_execution_environments_list(
+    session: Session, endpoint: str, env_name: Optional[str] = None
+) -> List[Dict[str, Any]]:
+    """Get a list of execution environments with possibility to filter by name"""
+    url = posixpath.join(endpoint, 'executionEnvironments/')
+    req_params = {'useCases': 'customApplication'}
+    if env_name:
+        req_params['searchFor'] = env_name
+
+    response = session.get(url, params=req_params)
+    handle_dr_response(response)
+
+    env_list = response.json()['data']
+    if env_name:
+        env_list = [ee for ee in env_list if ee['name'] == env_name]
+
+    return env_list

--- a/drapps/ls.py
+++ b/drapps/ls.py
@@ -1,0 +1,61 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+from typing import Any, Dict, List
+
+import click
+import requests
+from requests import Session
+from tabulate import tabulate
+
+from .helpers.custom_apps_functions import get_custom_apps_list
+from .helpers.execution_environments_functions import get_execution_environments_list
+from .helpers.wrappers import api_endpoint, api_token
+
+
+def format_table(data: List[Dict[str, Any]], headers: List[str]) -> str:
+    rows = []
+    for element in data:
+        rows.append([element[column] for column in headers])
+    return tabulate(rows, headers=headers, tablefmt='simple')
+
+
+def list_apps(session: Session, endpoint: str, id_only: bool) -> str:
+    apps = get_custom_apps_list(session, endpoint)
+
+    if id_only:
+        return ' '.join([app['id'] for app in apps])
+
+    headers = ['id', 'name', 'status', 'applicationUrl']
+    return format_table(apps, headers)
+
+
+def list_environments(session: Session, endpoint: str, id_only: bool) -> str:
+    envs = get_execution_environments_list(session, endpoint)
+
+    if id_only:
+        return ' '.join([ee['id'] for ee in envs])
+
+    headers = ['id', 'name', 'description']
+    return format_table(envs, headers)
+
+
+@click.command()
+@api_token
+@api_endpoint
+@click.option('--id-only', is_flag=True, show_default=True, default=False, help='Output only ids')
+@click.argument('entity', type=click.Choice(['apps', 'envs']))
+def ls(token: str, endpoint: str, id_only: bool, entity: str) -> None:
+    """Provide list of custom applications or execution environments."""
+    session = requests.Session()
+    session.headers.update({'Authorization': f'Bearer {token}'})
+
+    if entity == 'apps':
+        output = list_apps(session, endpoint, id_only)
+    else:
+        output = list_environments(session, endpoint, id_only)
+    click.echo(output)

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ install_requires = [
     'bson==0.5.10',
     'click==8.1.7',
     'requests==2.31.0',
+    'tabulate==0.9.0',
 ]
 
 tests_require = [
@@ -17,9 +18,10 @@ tests_require = [
     'responses==0.23.3',
     'black==23.12.0 ',
     'flake8==6.1.0',
+    'isort==5.13.2',
     'mypy==1.7.1',
     'types-requests==2.31.0.10',
-    'isort==5.13.2',
+    'types-tabulate==0.9.0.20240106'
 ]
 
 setup(

--- a/tests/cli/test_ls.py
+++ b/tests/cli/test_ls.py
@@ -1,0 +1,129 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import pytest
+import responses
+from click.testing import CliRunner
+from responses import matchers
+
+from drapps.ls import ls
+
+
+@responses.activate
+@pytest.mark.parametrize('ids_only', (False, True))
+def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
+    applications_list_data = {
+        'count': 3,
+        'data': [
+            {
+                'id': '65980d79eea4fd0eddd59bba',
+                'name': "App 1",
+                'status': 'running',
+                'applicationUrl': 'http://ho.st/custom_applications/65980d79eea4fd0eddd59bba/',
+                'envVersionId': '659964572522de6a026de5cf',
+            },
+            {
+                'id': '659964182522de6a026de5cd',
+                'name': "App 2",
+                'status': 'running',
+                'applicationUrl': 'http://ho.st/custom_applications/659964182522de6a026de5cd/',
+                'envVersionId': '659964572522de6a026de5d0',
+            },
+            {
+                'id': '659964382522de6a026de5ce',
+                'name': "App 3",
+                'status': 'running',
+                'applicationUrl': 'http://ho.st/custom_applications/659964382522de6a026de5ce/',
+                'envVersionId': '659964572522de6a026de5d1',
+            },
+        ],
+    }
+    if ids_only:
+        expected_output = (
+            '65980d79eea4fd0eddd59bba 659964182522de6a026de5cd 659964382522de6a026de5ce\n'
+        )
+    else:
+        expected_output = (
+            'id                        name    status    applicationUrl\n'
+            '------------------------  ------  --------  ----------------------------------------------------------\n'
+            '65980d79eea4fd0eddd59bba  App 1   running   http://ho.st/custom_applications/65980d79eea4fd0eddd59bba/\n'
+            '659964182522de6a026de5cd  App 2   running   http://ho.st/custom_applications/659964182522de6a026de5cd/\n'
+            '659964382522de6a026de5ce  App 3   running   http://ho.st/custom_applications/659964382522de6a026de5ce/\n'
+        )
+
+    app_list_url = f'{api_endpoint_env}/customApplications/'
+    auth_matcher = matchers.header_matcher(
+        {'Authorization': f'Bearer {api_token_env}'}
+    )  # checker for API token
+    responses.get(app_list_url, json=applications_list_data, match=[auth_matcher])
+
+    runner = CliRunner()
+    cli_args = ['apps']
+    if ids_only:
+        cli_args.append('--id-only')
+    result = runner.invoke(ls, cli_args)
+
+    assert result.exit_code == 0
+    assert result.output == expected_output
+
+
+@responses.activate
+@pytest.mark.parametrize('ids_only', (False, True))
+def test_ls_envs(api_endpoint_env, api_token_env, ids_only):
+    execution_envs_list_data = {
+        'count': 3,
+        'data': [
+            {
+                'id': '659966682522de6a026de5d2',
+                'name': 'Env 1',
+                'description': 'First example',
+                'programmingLanguage': 'python',
+            },
+            {
+                'id': '659966682522de6a026de5d3',
+                'name': 'Env 2',
+                'description': 'Second example',
+                'programmingLanguage': 'python',
+            },
+            {
+                'id': '659966682522de6a026de5d4',
+                'name': 'Env 3',
+                'description': 'Third example',
+                'programmingLanguage': 'python',
+            },
+        ],
+    }
+    if ids_only:
+        expected_output = (
+            '659966682522de6a026de5d2 659966682522de6a026de5d3 659966682522de6a026de5d4\n'
+        )
+    else:
+        expected_output = (
+            'id                        name    description\n'
+            '------------------------  ------  --------------\n'
+            '659966682522de6a026de5d2  Env 1   First example\n'
+            '659966682522de6a026de5d3  Env 2   Second example\n'
+            '659966682522de6a026de5d4  Env 3   Third example\n'
+        )
+
+    app_list_url = f'{api_endpoint_env}/executionEnvironments/'
+    auth_matcher = matchers.header_matcher(
+        {'Authorization': f'Bearer {api_token_env}'}
+    )  # checker for API token
+    params_matcher = matchers.query_param_matcher(
+        {'useCases': 'customApplication'}
+    )  # check that filter by use cases was used
+    responses.get(app_list_url, json=execution_envs_list_data, match=[auth_matcher, params_matcher])
+
+    runner = CliRunner()
+    cli_args = ['envs']
+    if ids_only:
+        cli_args.append('--id-only')
+    result = runner.invoke(ls, cli_args)
+
+    assert result.exit_code == 0
+    assert result.output == expected_output


### PR DESCRIPTION
Added `ls` command

```
Usage: ls [OPTIONS] {apps|envs}

  Provide list of custom applications or execution environments.

Options:
  -t, --token TEXT     Pubic API access token.
  -E, --endpoint TEXT  Data Robot Public API endpoint.
  --id-only            Output only ids
  --help               Show this message and exit.
```