### PR TITLE
[APPLS-1799] Added terminate command

### DIFF
--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -43,7 +43,7 @@ def get_custom_app_by_name(session: Session, endpoint: str, app_name: str) -> Di
         # imitating that app is not found
         error_url = posixpath.join(endpoint, 'customApplications/')
         raise ClientResponseError(
-            status=404, message='Can\'t find custom application by name', url=error_url
+            status=404, message='Can\'t find custom application by name.', url=error_url
         )
     return apps[0]
 

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -10,13 +10,14 @@ from typing import Any, Dict, List, Optional
 
 from requests import Session
 
+from .exceptions import ClientResponseError
 from .handle_dr_response import handle_dr_response
 
 
 def get_custom_apps_list(
     session: Session, endpoint: str, app_name: Optional[str] = None
 ) -> List[Dict[str, Any]]:
-    """Get a list of custom application with possibility to filter by application name"""
+    """Get a list of custom application with possibility to filter by application name."""
     url = posixpath.join(endpoint, 'customApplications/')
     req_params = {}
     if app_name:
@@ -28,17 +29,36 @@ def get_custom_apps_list(
 
 
 def get_custom_app_by_id(session: Session, endpoint: str, app_id: str) -> Dict[str, Any]:
-    """Get a custom application by ID"""
+    """Get a custom application by ID."""
     url = posixpath.join(endpoint, f'customApplications/{app_id}/')
     response = session.get(url)
     handle_dr_response(response)
     return response.json()
 
 
+def get_custom_app_by_name(session: Session, endpoint: str, app_name: str) -> Dict[str, Any]:
+    """Get a custom application by name."""
+    apps = get_custom_apps_list(session, endpoint, app_name=app_name)
+    if not apps:
+        # imitating that app is not found
+        error_url = posixpath.join(endpoint, 'customApplications/')
+        raise ClientResponseError(
+            status=404, message='Can\'t find custom application by name', url=error_url
+        )
+    return apps[0]
+
+
 def get_custom_app_logs(session: Session, endpoint: str, app_id: str) -> str:
-    """Get runtime logs for a custom application"""
+    """Get runtime logs for a custom application."""
     url = posixpath.join(endpoint, f'customApplications/{app_id}/logs/')
     response = session.get(url)
     handle_dr_response(response)
     records = response.json()['logs']
     return '\n'.join(records)
+
+
+def delete_custom_app(session: Session, endpoint: str, app_id: str) -> None:
+    """Delete custom application."""
+    url = posixpath.join(endpoint, f'customApplications/{app_id}/')
+    response = session.delete(url)
+    handle_dr_response(response)

--- a/drapps/helpers/wrappers.py
+++ b/drapps/helpers/wrappers.py
@@ -31,7 +31,9 @@ def api_token(command: Callable[..., None]) -> Callable[..., None]:
     for attr in MIMIC_ATTRIBUTES:
         if hasattr(command, attr):
             setattr(wrapper, attr, getattr(command, attr))
-    option_wrapper = click.option('-t', '--token', type=str, help='Pubic API access token.')
+    option_wrapper = click.option(
+        '-t', '--token', type=click.STRING, help='Pubic API access token.'
+    )
     return option_wrapper(wrapper)
 
 
@@ -50,6 +52,6 @@ def api_endpoint(command: Callable[..., None]) -> Callable[..., None]:
         if hasattr(command, attr):
             setattr(wrapper, attr, getattr(command, attr))
     option_wrapper = click.option(
-        '-E', '--endpoint', type=str, help='Data Robot Public API endpoint.'
+        '-E', '--endpoint', type=click.STRING, help='Data Robot Public API endpoint.'
     )
     return option_wrapper(wrapper)

--- a/drapps/ls.py
+++ b/drapps/ls.py
@@ -8,7 +8,6 @@
 from typing import Any, Dict, List
 
 import click
-import requests
 from requests import Session
 from tabulate import tabulate
 
@@ -28,7 +27,7 @@ def list_apps(session: Session, endpoint: str, id_only: bool) -> str:
     apps = get_custom_apps_list(session, endpoint)
 
     if id_only:
-        return ' '.join([app['id'] for app in apps])
+        return '\n'.join([app['id'] for app in apps])
 
     headers = ['id', 'name', 'status', 'applicationUrl']
     return format_table(apps, headers)
@@ -38,7 +37,7 @@ def list_environments(session: Session, endpoint: str, id_only: bool) -> str:
     envs = get_execution_environments_list(session, endpoint)
 
     if id_only:
-        return ' '.join([ee['id'] for ee in envs])
+        return '\n'.join([ee['id'] for ee in envs])
 
     headers = ['id', 'name', 'description']
     return format_table(envs, headers)
@@ -51,7 +50,7 @@ def list_environments(session: Session, endpoint: str, id_only: bool) -> str:
 @click.argument('entity', type=click.Choice(['apps', 'envs']))
 def ls(token: str, endpoint: str, id_only: bool, entity: str) -> None:
     """Provide list of custom applications or execution environments."""
-    session = requests.Session()
+    session = Session()
     session.headers.update({'Authorization': f'Bearer {token}'})
 
     if entity == 'apps':

--- a/drapps/terminate.py
+++ b/drapps/terminate.py
@@ -71,9 +71,9 @@ def terminate(token: str, endpoint: str, application_id_or_name: Tuple[str]) -> 
             remove_app(session, endpoint, app_id_name)
         except ClientResponseError as error:
             if error.status == 404:
-                click.echo(f'Cannot find application {app_id_name}.')
+                click.echo(f'Cannot find application {app_id_name}.', err=True)
             elif error.status == 403:
-                click.echo(f'No permissions for deleting {app_id_name}.')
+                click.echo(f'No permissions for deleting {app_id_name}.', err=True)
             else:
                 raise error
         else:

--- a/drapps/terminate.py
+++ b/drapps/terminate.py
@@ -1,0 +1,80 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import sys
+from typing import Any, Tuple
+
+import click
+from bson import ObjectId
+from requests import Session
+
+from .helpers.custom_apps_functions import get_custom_app_by_name, delete_custom_app
+from .helpers.exceptions import ClientResponseError
+from .helpers.wrappers import api_endpoint, api_token
+
+
+def remove_app(session: Session, endpoint: str, application_id_or_name: str):
+    if ObjectId.is_valid(application_id_or_name):
+        app_id = application_id_or_name
+    else:
+        app = get_custom_app_by_name(session, endpoint, app_name=application_id_or_name)
+        app_id = app['id']
+
+    delete_custom_app(session, endpoint, app_id)
+
+
+class RequiredStringsFromParamsAndStdin(click.Argument):
+    """
+    Custom argument that tries getting value from parameters and if fails,
+    try to read from stdin stream.
+    """
+
+    def __init__(self, *args, **kwargs):
+        kwargs['nargs'] = -1
+        kwargs['type'] = click.STRING
+        kwargs['required'] = True
+        super().__init__(*args, **kwargs)
+
+    def process_value(self, ctx: click.Context, value: Any) -> Any:
+        value = self.type_cast_value(ctx, value)
+
+        if self.value_is_missing(value) and not sys.stdin.isatty():
+            # if we have no value but sys.stdin attached to file
+            # we make a try to read from file
+            stdin_text = click.get_text_stream('stdin')
+            value = tuple(line.strip() for line in stdin_text.readlines())
+
+        if self.value_is_missing(value):
+            raise click.MissingParameter(ctx=ctx, param=self)
+
+        if self.callback is not None:
+            value = self.callback(ctx, self, value)
+
+        return value
+
+
+@click.command()
+@api_token
+@api_endpoint
+@click.argument("application_id_or_name", cls=RequiredStringsFromParamsAndStdin)
+def terminate(token: str, endpoint: str, application_id_or_name: Tuple[str]) -> None:
+    """Stops custom application and removes it from the list."""
+    session = Session()
+    session.headers.update({'Authorization': f'Bearer {token}'})
+
+    for app_id_name in application_id_or_name:
+        try:
+            remove_app(session, endpoint, app_id_name)
+        except ClientResponseError as error:
+            if error.status == 404:
+                click.echo(f'Cannot find application {app_id_name}.')
+            elif error.status == 403:
+                click.echo(f'No permissions for deleting {app_id_name}.')
+            else:
+                raise error
+        else:
+            click.echo(f'Custom application {app_id_name} was deleted.')

--- a/tests/cli/test_logs.py
+++ b/tests/cli/test_logs.py
@@ -44,7 +44,7 @@ def test_logs(api_endpoint_env, api_token_env, use_name):
 
     runner = CliRunner()
     result = runner.invoke(logs, [identifier])
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.exception
     assert result.output == app_logs + '\n'
 
 

--- a/tests/cli/test_ls.py
+++ b/tests/cli/test_ls.py
@@ -44,7 +44,7 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
     }
     if ids_only:
         expected_output = (
-            '65980d79eea4fd0eddd59bba\n' '659964182522de6a026de5cd\n' '659964382522de6a026de5ce\n'
+            '65980d79eea4fd0eddd59bba\n659964182522de6a026de5cd\n659964382522de6a026de5ce\n'
         )
     else:
         expected_output = (
@@ -99,7 +99,7 @@ def test_ls_envs(api_endpoint_env, api_token_env, ids_only):
     }
     if ids_only:
         expected_output = (
-            '659966682522de6a026de5d2\n' '659966682522de6a026de5d3\n' '659966682522de6a026de5d4\n'
+            '659966682522de6a026de5d2\n659966682522de6a026de5d3\n659966682522de6a026de5d4\n'
         )
     else:
         expected_output = (

--- a/tests/cli/test_ls.py
+++ b/tests/cli/test_ls.py
@@ -44,7 +44,7 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
     }
     if ids_only:
         expected_output = (
-            '65980d79eea4fd0eddd59bba 659964182522de6a026de5cd 659964382522de6a026de5ce\n'
+            '65980d79eea4fd0eddd59bba\n' '659964182522de6a026de5cd\n' '659964382522de6a026de5ce\n'
         )
     else:
         expected_output = (
@@ -67,7 +67,7 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
         cli_args.append('--id-only')
     result = runner.invoke(ls, cli_args)
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.exception
     assert result.output == expected_output
 
 
@@ -99,7 +99,7 @@ def test_ls_envs(api_endpoint_env, api_token_env, ids_only):
     }
     if ids_only:
         expected_output = (
-            '659966682522de6a026de5d2 659966682522de6a026de5d3 659966682522de6a026de5d4\n'
+            '659966682522de6a026de5d2\n' '659966682522de6a026de5d3\n' '659966682522de6a026de5d4\n'
         )
     else:
         expected_output = (
@@ -125,5 +125,5 @@ def test_ls_envs(api_endpoint_env, api_token_env, ids_only):
         cli_args.append('--id-only')
     result = runner.invoke(ls, cli_args)
 
-    assert result.exit_code == 0
+    assert result.exit_code == 0, result.exception
     assert result.output == expected_output

--- a/tests/cli/test_terminate.py
+++ b/tests/cli/test_terminate.py
@@ -1,0 +1,112 @@
+#
+#  Copyright 2024 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import json
+
+import pytest
+import responses
+from bson import ObjectId
+
+from click.testing import CliRunner
+from responses import matchers
+
+from drapps.terminate import terminate
+
+
+@responses.activate
+@pytest.mark.parametrize('use_name', (False, True))
+def test_terminate(api_endpoint_env, api_token_env, use_name):
+    app_id = str(ObjectId())
+    app_name = 'app_name'
+
+    # checker for API token
+    auth_matcher = matchers.header_matcher({'Authorization': f'Bearer {api_token_env}'})
+    if use_name:
+        app_list_url = f'{api_endpoint_env}/customApplications/'
+        # check that name filter was used
+        params_matcher = matchers.query_param_matcher({'name': app_name})
+        responses.get(
+            app_list_url,
+            json={'count': 1, 'data': [{'id': app_id, 'name': app_name}]},
+            match=[auth_matcher, params_matcher],
+        )
+
+    app_url = f'{api_endpoint_env}/customApplications/{app_id}/'
+    responses.delete(app_url, status=204, match=[auth_matcher])
+
+    identifier = app_name if use_name else app_id
+
+    runner = CliRunner()
+    result = runner.invoke(terminate, [identifier])
+    assert result.exit_code == 0, result.exception
+    assert result.output == f'Custom application {identifier} was deleted.\n'
+
+
+@responses.activate
+@pytest.mark.usefixtures('api_token_env')
+@pytest.mark.parametrize('from_input_stream', (False, True))
+def test_terminate_list(api_endpoint_env, from_input_stream):
+    applications = {'App_1': str(ObjectId()), 'App_2': str(ObjectId()), 'App_3': str(ObjectId())}
+
+    def request_callback(request):
+        app_name = request.params['name']
+        app_id = applications[app_name]
+        resp_body = {'count': 1, 'data': [{'id': app_id, 'name': app_name}]}
+        return 200, {}, json.dumps(resp_body)
+
+    responses.add_callback(
+        responses.GET,
+        f'{api_endpoint_env}/customApplications/',
+        callback=request_callback,
+        content_type="application/json",
+    )
+
+    for app_id in applications.values():
+        responses.delete(f'{api_endpoint_env}/customApplications/{app_id}/', status=204)
+
+    runner = CliRunner()
+
+    if from_input_stream:
+        # provide names through stdin to imitate shell pipes
+        input_stream = ''.join(f'{key}\n' for key in applications.keys())
+        params = {'input': input_stream}
+    else:
+        # provide names as command arguments
+        params = {'args': list(applications.keys())}
+
+    result = runner.invoke(terminate, **params)
+    assert result.exit_code == 0, result.exception
+
+    expected_output = ''.join(
+        [f'Custom application {app_name} was deleted.\n' for app_name in applications.keys()]
+    )
+    assert result.output == expected_output
+
+
+@responses.activate
+@pytest.mark.usefixtures('api_token_env')
+def test_terminate_handle_errors(api_endpoint_env):
+    call_params = ['659eec8f2522de35c1b2c8a6', 'wrong_name', '659eec492522de2b78175c01']
+
+    # app does not exist
+    responses.delete(f'{api_endpoint_env}/customApplications/659eec8f2522de35c1b2c8a6/', status=404)
+    # no app with such name
+    responses.get(
+        f'{api_endpoint_env}/customApplications/?name=wrong_name', json={'count': 0, 'data': []}
+    )
+    # no permissions for deleting this app
+    responses.delete(f'{api_endpoint_env}/customApplications/659eec492522de2b78175c01/', status=403)
+
+    runner = CliRunner()
+    result = runner.invoke(terminate, call_params)
+
+    expected_output = (
+        'Cannot find application 659eec8f2522de35c1b2c8a6.\n'
+        'Cannot find application wrong_name.\n'
+        'No permissions for deleting 659eec492522de2b78175c01.\n'
+    )
+    assert result.output == expected_output


### PR DESCRIPTION
Added terminate command.
```
Usage: drapps terminate [OPTIONS] APPLICATION_ID_OR_NAME...

  Provide logs for custom application.

Options:
  -t, --token TEXT     Pubic API access token.
  -E, --endpoint TEXT  Data Robot Public API endpoint.
  --help               Show this message and exit.
```

It accept applications names and IDs:
```
drapps terminate app_name_1 app_name_2
```
And piping is also possible:
```
drapps ls --id-only apps | drapps terminate
```