### PR TITLE
[APPLS-1946] Allow drapps to work via a module command (python -m drapps ... )

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,9 +19,19 @@ pip install git+https://github.com/datarobot/dr-apps
 To install the DRApps CLI tool, clone this 
 respository and then install package by running the following command:
 
-``` sh
+``` sh 
 python setup.py install
 ```
+
+## For Windows Users
+
+For Windows users, you may need to interface with the DR Custom Apps CLI via module calls:
+
+```sh
+python -m drapps <your_commands_here>
+```
+If you have issues entering words with spaces ( eg: `-e "[Experimental] Python 3.9 Streamlit"` )
+then you may find that using ids is a little easier.
 
 ## Use the DRApps CLI
 

--- a/bin/drapps
+++ b/bin/drapps
@@ -6,21 +6,8 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
-from click import Group
+from drapps.__main__ import drapps
 
-from drapps.create import create
-from drapps.logs import logs
-from drapps.ls import ls
-from drapps.terminate import terminate
-
-help_text = (
-    'CLI tools for custom applications.\n\n'
-    'You can use drapps COMMAND --help for getting more info about command.'
-)
-drapps = Group(
-    commands=[create, ls, logs, terminate],
-    help=help_text,
-)
 
 if __name__ == "__main__":
     drapps()

--- a/drapps/__main__.py
+++ b/drapps/__main__.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+from click import Group
+
+from drapps.create import create
+from drapps.logs import logs
+from drapps.ls import ls
+from drapps.terminate import terminate
+
+help_text = (
+    'CLI tools for custom applications.\n\n'
+    'You can use drapps COMMAND --help for getting more info about command.'
+)
+drapps = Group(
+    commands=[create, ls, logs, terminate],
+    help=help_text,
+)
+
+if __name__ == "__main__":
+    drapps()


### PR DESCRIPTION
I went through the flow of installing Python on a Windows laptop, and uploading an app. I ran into issues registering the drapps python code, and decided the most portable experience was to just make it a module. I also had trouble with the named execution environment, but using an ID worked, so I wanted to note that. 