### PR TITLE
[APP-2623] Automatically add `association_id` as a field to Streamlit Apps

### DIFF
--- a/examples/prediction-demo/dr_streamlit/create_prediction.py
+++ b/examples/prediction-demo/dr_streamlit/create_prediction.py
@@ -30,7 +30,17 @@ def get_prediction_features(project_id: str, deployment_id: str) -> List[Dict[st
             histogram = FeatureHistogram.get(project_id=project_id, feature_name=d_feature['name'])
             record['options'] = [option['label'] for option in histogram.plot]
         prediction_features.append(record)
-
+    if Deployment(deployment_id).get_association_id_settings()['required_in_prediction_requests'] == True:
+        association_id = Deployment(deployment_id).get_association_id_settings()['column_names'][0]
+        record = {
+            'name': association_id,
+            'feature_type': 'Text',
+            'date_format': None,
+            'min': None,
+            'max': None,
+            'median': None,
+            'suspected_int': False}
+        prediction_features.append(record)
     return prediction_features
 
 


### PR DESCRIPTION
- Used the code provided in the JIRA ticket by Olga.
- I've assumed the datatype to be `Text` instead of `Numeric`.
- Tried running the predictions locally and verified that they work as expected for `association_id` that consists of both letters and just numbers.