### PR TITLE
[APP-2754] Add create_env command to drapps CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,29 @@ Argument                | Description
 `--token`               | Enter your API Key, found on the [**Developer Tools**](https://app.datarobot.com/account/developer-tools) page of your DataRobot account. <br> You can also provide your API Key using the `DATAROBOT_API_TOKEN` environment variable.
 `--endpoint`            | Enter the URL for the DataRobot Public API. The default value is `https://app.datarobot.com/api/v2`. <br> You can also provide the URL to Public API using the `DATAROBOT_ENDPOINT` environment variable.
 
+### Create a new Execution Environment
+It may be the case that your version of DataRobot (eg Single Tenant SAAS or On-Prem) was not shipped with the `[Experimental] Python 3.9 Streamlit`
+or that you want to make a new execution environment for your apps (eg you want to make a Flask app, or you want your base docker image
+to have some packages installed in it that don't come standard
+
+First you will need to make a dockerfile. For the default `[Experimental] Python 3.9 Streamlit` env we use:
+```dockerfile
+FROM python:3.9-slim
+
+WORKDIR /app
+
+RUN pip3 install --no-cache-dir 'streamlit==1.17.0' 'datarobot==3.0.2' 'plotly==5.13.0' 'streamlit-wordcloud==0.1.0' 'kaleido==0.2.1' 'tabulate==0.9.0' 'altair<5'
+
+WORKDIR /opt/code
+
+EXPOSE 8080
+```
+That dockerfile will then need to be archived into a zip file. For this example we named the zip file `dockerfile.zip`.
+Once you have the file zipped, and you open a terminal in the directory you can use the apps CLI:
+```
+drapps create-env --dockerfilezip dockerfile.zip --name "[Experimental] Python 3.9 Streamlit"
+```
+
 ## Deploy an example app
 
 To test this, deploy an example Streamlit app using the following command from 

--- a/drapps/__main__.py
+++ b/drapps/__main__.py
@@ -9,6 +9,7 @@
 from click import Group
 
 from drapps.create import create
+from drapps.env import create_env
 from drapps.logs import logs
 from drapps.ls import ls
 from drapps.terminate import terminate
@@ -18,7 +19,7 @@ help_text = (
     'You can use drapps COMMAND --help for getting more info about command.'
 )
 drapps = Group(
-    commands=[create, ls, logs, terminate],
+    commands=[create, ls, logs, terminate, create_env],
     help=help_text,
 )
 

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -192,12 +192,12 @@ def wait_for_execution_environment_version_ready(
 
 
 def send_docker_image_with_progress(
-    session: Session, endpoint: str, base_env_id: str, docker_image: Path
+    session: Session, endpoint: str, base_env_id: str, docker_image: Path, field_name: str = 'docker_image'
 ) -> None:
     click.echo(f'Uploading {docker_image.name} to Data Robot.')
     with docker_image.open('rb') as file:
         multipart_monitor = MultipartEncoderMonitor.from_fields(
-            fields={'docker_image': (docker_image.name, file, 'application/octet-stream')}
+            fields={field_name: (docker_image.name, file, 'application/octet-stream')}
         )
         progress: ProgressBar  # type hinting badly needed by mypy
         with click.progressbar(length=multipart_monitor.len, label='Upload progress:') as progress:

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -192,7 +192,11 @@ def wait_for_execution_environment_version_ready(
 
 
 def send_docker_image_with_progress(
-    session: Session, endpoint: str, base_env_id: str, docker_image: Path, field_name: str = 'docker_image'
+    session: Session,
+    endpoint: str,
+    base_env_id: str,
+    docker_image: Path,
+    field_name: str = 'docker_image',
 ) -> None:
     click.echo(f'Uploading {docker_image.name} to Data Robot.')
     with docker_image.open('rb') as file:

--- a/drapps/env.py
+++ b/drapps/env.py
@@ -41,7 +41,9 @@ from .helpers.wrappers import api_endpoint, api_token
     type=click.STRING,
     help='Description of the execution env to be created',
 )
-def create_env(token: str, endpoint: str, name: str, dockerfilezip: Path, description: Optional[str]) -> None:
+def create_env(
+    token: str, endpoint: str, name: str, dockerfilezip: Path, description: Optional[str]
+) -> None:
     """Creates an execution environment and a first version."""
     session = Session()
     session.headers.update({'Authorization': f'Bearer {token}'})
@@ -58,6 +60,6 @@ def create_env(token: str, endpoint: str, name: str, dockerfilezip: Path, descri
         endpoint=endpoint,
         base_env_id=create_exec_env_rsp['id'],
         docker_image=dockerfilezip,
-        field_name='docker_context'
+        field_name='docker_context',
     )
     click.echo()

--- a/drapps/env.py
+++ b/drapps/env.py
@@ -1,0 +1,63 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+from pathlib import Path
+from typing import Optional
+
+import click
+from requests import Session
+
+from .create import send_docker_image_with_progress
+from .helpers.execution_environments_functions import create_execution_environment
+from .helpers.wrappers import api_endpoint, api_token
+
+
+@click.command()
+@api_token
+@api_endpoint
+@click.option(
+    '-n',
+    '--name',
+    required=True,
+    type=click.STRING,
+    help='Name of the execution env to be created',
+)
+@click.option(
+    '-i',
+    '--dockerfilezip',
+    required=False,
+    type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=Path),
+    help='Path to tar archive which contains dockerfile',
+)
+@click.option(
+    '-d',
+    '--description',
+    required=False,
+    default=None,
+    type=click.STRING,
+    help='Description of the execution env to be created',
+)
+def create_env(token: str, endpoint: str, name: str, dockerfilezip: Path, description: Optional[str]) -> None:
+    """Creates an execution environment and a first version."""
+    session = Session()
+    session.headers.update({'Authorization': f'Bearer {token}'})
+    click.echo('Creating execution environment')
+    create_exec_env_rsp = create_execution_environment(
+        session=session,
+        endpoint=endpoint,
+        env_name=name,
+        description=description,
+    )
+    click.echo("Created Exec Environment")
+    send_docker_image_with_progress(
+        session=session,
+        endpoint=endpoint,
+        base_env_id=create_exec_env_rsp['id'],
+        docker_image=dockerfilezip,
+        field_name='docker_context'
+    )
+    click.echo()

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.2.3
+version = 0.2.4

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -1,0 +1,63 @@
+#
+#  Copyright 2023 DataRobot, Inc. and its affiliates.
+#
+#  All rights reserved.
+#  This is proprietary source code of DataRobot, Inc. and its affiliates.
+#  Released under the terms of DataRobot Tool and Utility Agreement.
+#
+import logging
+from unittest.mock import patch
+
+import pytest
+import responses
+from bson import ObjectId
+from click.testing import CliRunner
+from responses import matchers
+
+from drapps.env import create_env
+
+
+@responses.activate
+@pytest.mark.parametrize('image_name', ['dockerfile.tgz'])
+@pytest.mark.parametrize('env_name', ["My New Execution Env"])
+@pytest.mark.parametrize('description', ["This is an Exec Env", None] )
+def test_create_env_with_version(api_endpoint_env, api_token_env, image_name, description, env_name):
+    execution_environments_id = ObjectId()
+    auth_matcher = matchers.header_matcher(
+        {'Authorization': f'Bearer {api_token_env}'}
+    )  # checker for API token
+
+    # setup + test execution env
+    exec_env_url = f'{api_endpoint_env}/executionEnvironments/'
+    exec_env_matcher = {
+        'name': env_name,
+        'useCases': ['customApplication'],
+    }
+    if description is not None:
+        exec_env_matcher['description'] = description
+    responses.post(exec_env_url, json={'id': str(execution_environments_id)}, match=[auth_matcher, matchers.json_params_matcher(exec_env_matcher)])
+
+    # setup + test version
+    exec_env_version_url = f'{api_endpoint_env}/executionEnvironments/{execution_environments_id}/versions/'
+    version_id = str(ObjectId())
+    responses.post(exec_env_version_url, json={'id': version_id}, match=[auth_matcher])
+
+    exec_env_version_status_url = f'{api_endpoint_env}/executionEnvironments/{execution_environments_id}/versions/{version_id}/'
+    exec_env_version_rsp = {
+        "buildStatus": "success",
+    }
+    responses.get(exec_env_version_status_url, json=exec_env_version_rsp, match=[auth_matcher])
+
+    runner = CliRunner()
+    with runner.isolated_filesystem():
+        with open(image_name, 'wb') as image_file:
+            image_file.write(b'Some data')
+
+        with patch('drapps.create.CHECK_STATUS_WAIT_TIME', 0):
+            result = runner.invoke(create_env, ["--name", env_name, "-i", image_name, '-d', description])
+    logger = logging.getLogger()
+    if result.exit_code:
+        logger.error(result.output)
+    else:
+        logger.info(result.output)
+    assert result.exit_code == 0, result.exception

--- a/tests/cli/test_env.py
+++ b/tests/cli/test_env.py
@@ -20,8 +20,10 @@ from drapps.env import create_env
 @responses.activate
 @pytest.mark.parametrize('image_name', ['dockerfile.tgz'])
 @pytest.mark.parametrize('env_name', ["My New Execution Env"])
-@pytest.mark.parametrize('description', ["This is an Exec Env", None] )
-def test_create_env_with_version(api_endpoint_env, api_token_env, image_name, description, env_name):
+@pytest.mark.parametrize('description', ["This is an Exec Env", None])
+def test_create_env_with_version(
+    api_endpoint_env, api_token_env, image_name, description, env_name
+):
     execution_environments_id = ObjectId()
     auth_matcher = matchers.header_matcher(
         {'Authorization': f'Bearer {api_token_env}'}
@@ -35,10 +37,16 @@ def test_create_env_with_version(api_endpoint_env, api_token_env, image_name, de
     }
     if description is not None:
         exec_env_matcher['description'] = description
-    responses.post(exec_env_url, json={'id': str(execution_environments_id)}, match=[auth_matcher, matchers.json_params_matcher(exec_env_matcher)])
+    responses.post(
+        exec_env_url,
+        json={'id': str(execution_environments_id)},
+        match=[auth_matcher, matchers.json_params_matcher(exec_env_matcher)],
+    )
 
     # setup + test version
-    exec_env_version_url = f'{api_endpoint_env}/executionEnvironments/{execution_environments_id}/versions/'
+    exec_env_version_url = (
+        f'{api_endpoint_env}/executionEnvironments/{execution_environments_id}/versions/'
+    )
     version_id = str(ObjectId())
     responses.post(exec_env_version_url, json={'id': version_id}, match=[auth_matcher])
 
@@ -54,7 +62,9 @@ def test_create_env_with_version(api_endpoint_env, api_token_env, image_name, de
             image_file.write(b'Some data')
 
         with patch('drapps.create.CHECK_STATUS_WAIT_TIME', 0):
-            result = runner.invoke(create_env, ["--name", env_name, "-i", image_name, '-d', description])
+            result = runner.invoke(
+                create_env, ["--name", env_name, "-i", image_name, '-d', description]
+            )
     logger = logging.getLogger()
     if result.exit_code:
         logger.error(result.output)


### PR DESCRIPTION
With the launch of 10.0, some customers using on-prem or ST SAAS DataRobot will need to have a base execution environment. Other customers may want to make execution environments which have different base images (eg use python 3.12) or different versions (eg users making a flask app who don't want streamlit) 

This PR consolidates a few commands together to make creating an execution environment as easy as a few commands. 