### PR TITLE
[APP-2756] Fix bug for the example demo for DR Serverless prediction environments

### DIFF
--- a/examples/prediction-demo/dr_streamlit/predictor.py
+++ b/examples/prediction-demo/dr_streamlit/predictor.py
@@ -6,6 +6,7 @@ import numpy as np
 import pandas as pd
 from datarobot import Deployment, Project, TARGET_TYPE, BatchPredictionJob
 from datarobot.client import get_client, Client
+
 from .caches import get_model
 
 

--- a/examples/prediction-demo/dr_streamlit/predictor.py
+++ b/examples/prediction-demo/dr_streamlit/predictor.py
@@ -6,9 +6,14 @@ import numpy as np
 import pandas as pd
 from datarobot import Deployment, Project, TARGET_TYPE, BatchPredictionJob
 from datarobot.client import get_client, Client
-
 from .caches import get_model
 
+
+def is_deployment_serverless(deployment: Deployment) -> bool:
+    """
+    Returns true if a deployment has `DataRobot Serverless` as the prediction environment, else false.
+    """
+    return deployment.prediction_environment.get('platform') == 'datarobotServerless'
 
 @st.cache
 def submit_prediction(
@@ -21,15 +26,20 @@ def submit_prediction(
     so this is a basic implementation
     """
     client: Client = get_client()
+    is_serverless = is_deployment_serverless(deployment)
     headers = {
         "Content-Type": "application/json; charset=UTF-8",
         "Authorization": client.headers["Authorization"],
-        "DataRobot-Key": deployment.default_prediction_server['datarobot-key'],
+        "DataRobot-Key": None if is_serverless else deployment.default_prediction_server['datarobot-key'],
     }
 
+    if is_serverless:
+        url = f'deployments/{deployment.id}/predictions'
+    else:
+        url = f'{deployment.prediction_environment["name"]}/predApi/v1.0/deployments/{deployment.id}/predictions'
     rsp = client.request(
         method='post',
-        url=f'{deployment.prediction_environment["name"]}/predApi/v1.0/deployments/{deployment.id}/predictions',
+        url=url,
         data=prediction_data.to_json(orient="records"),
         params={
             "maxExplanations": max_explanations,

--- a/examples/prediction-demo/requirements.txt
+++ b/examples/prediction-demo/requirements.txt
@@ -1,7 +1,7 @@
 streamlit == 1.17.0
 pytest == 7.2.1
 responses==0.22.0
-datarobot==3.0.2
+datarobot==3.4.0
 plotly==5.13.0
 streamlit-wordcloud==0.1.0
 kaleido==0.2.1


### PR DESCRIPTION
- Here's the JIRA Ticket: [APP-2756](https://datarobot.atlassian.net/browse/APP-2756)
### Rationale:
- The code checks if the prediction environment is `serverless` before making the prediction request.
- Also bumped up the `datarobot` python library version from `3.0.2` to `3.4.0`.
- Verified that the predictions work successfully for both `Serverless` and `Staging` environments.

[APP-2756]: https://datarobot.atlassian.net/browse/APP-2756?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ