### PR TITLE
[APP-2810] Use standardized versioning for dr-apps

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 0.2.4
+version = 10.1.4


### PR DESCRIPTION
Some consumers of the dr-apps CLI use the 10.0 version of DR (such as On Prem or Single Tenant users), and some users are on 10.1 because they are cloud users. 

Having breaking changes has already caused some pain since `customApplicationSources` was introduced as part of  10.1 and deprecated `customApplicationImages` which is part of 10.0, so the 10.1 CLI is not compatible with 10.0 since the CLI references an API which does not exist. Other libraries, like [python's Kubernetes library](https://github.com/kubernetes-client/python?tab=readme-ov-file#homogenizing-the-kubernetes-python-client-versions) follow this pattern, so I think it makes sense to do this too. 

As the custom apps product matures, it may be confusing if we make more changes like this. We hope that this means:
1. On-Prem or Single Tenant users of an install like 10.0 can simply pin their `dr-apps` requirement to `>=10.0.0,<10.1.0`
2. It's easier to know what version of apps the CLI corresponds to
3. It's easier to communicate what versions of the CLI are deprecated
