### PR TITLE
[APP-2837] Add `errors` when available to the error message given by `ClientResponseError`

### DIFF
--- a/drapps/helpers/exceptions.py
+++ b/drapps/helpers/exceptions.py
@@ -6,12 +6,12 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 
-from typing import Any, Dict, Optional
+from typing import Dict, Optional
 
 
 class ClientResponseError(Exception):
     def __init__(
-        self, url: str, status: int, message: str, errors: Optional[Dict[Any, Any]] = None
+        self, url: str, status: int, message: str, errors: Optional[Dict[str, str]] = None
     ):
         self.url = url
         self.status = status

--- a/drapps/helpers/exceptions.py
+++ b/drapps/helpers/exceptions.py
@@ -6,12 +6,19 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 
+from typing import Any, Dict, Optional
+
 
 class ClientResponseError(Exception):
-    def __init__(self, url: str, status: int, message: str):
+    def __init__(
+        self, url: str, status: int, message: str, errors: Optional[Dict[Any, Any]] = None
+    ):
         self.url = url
         self.status = status
         self.message = message
+        self.errors = errors
 
     def __str__(self) -> str:
+        if self.errors:
+            return f'{self.status}, message={self.message}, url={self.url}, errors={self.errors}'
         return f'{self.status}, message={self.message}, url={self.url}'

--- a/drapps/helpers/handle_dr_response.py
+++ b/drapps/helpers/handle_dr_response.py
@@ -24,10 +24,7 @@ def handle_dr_response(response: Response, raise_error: bool = True) -> None:
             message = response.reason
             errors = None
         exception = ClientResponseError(
-            url=response.url,
-            status=response.status_code,
-            message=message,
-            errors=errors
+            url=response.url, status=response.status_code, message=message, errors=errors
         )
         if raise_error:
             raise exception

--- a/drapps/helpers/handle_dr_response.py
+++ b/drapps/helpers/handle_dr_response.py
@@ -19,12 +19,15 @@ def handle_dr_response(response: Response, raise_error: bool = True) -> None:
         try:
             data = response.json()
             message = data.get('message', response.reason)
+            errors = data.get('errors', None)
         except JSONDecodeError:
             message = response.reason
+            errors = None
         exception = ClientResponseError(
             url=response.url,
             status=response.status_code,
             message=message,
+            errors=errors
         )
         if raise_error:
             raise exception


### PR DESCRIPTION
- JIRA Ticket: [APP-2837](https://datarobot.atlassian.net/browse/APP-2837)
- The `errors` argument is of type `Dict`. It can have multiple key-value pairs where the keys are the type of the error.
- Here's an example:
    - `drapps.helpers.exceptions.ClientResponseError: 422, message=Invalid field data, url=https://staging.datarobot.com/api/v2/customApplicationSources/667c6e24a92a7259bce1c64c/versions/667c6e24cdfbac19fc7cfeb0/, errors={'filePaths': 'Do not use metadata.yaml file. We do not support runtime parameters.'}`


[APP-2837]: https://datarobot.atlassian.net/browse/APP-2837?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ