### PR TITLE
[APP 2834] Add CLI flag for monitoring publication status

### DIFF
--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -114,7 +114,9 @@ def update_running_custom_app(
 
 
 def wait_for_publish_to_complete(session: Session, status_url: str):
-    click.echo("Waiting for publish to complete, the app will be ready when the old version is stopped")
+    click.echo(
+        "Waiting for publish to complete, the app will be ready when the old version is stopped"
+    )
     for _ in range(100):
         response = session.get(status_url)
         handle_dr_response(response)
@@ -123,4 +125,6 @@ def wait_for_publish_to_complete(session: Session, status_url: str):
             click.echo("New App is ready!")
             return
         else:
-            click.echo(f"The old version is {status['oldAppStatus']}, the new version is {status['appStatus']}")
+            click.echo(
+                f"The old version is {status['oldAppStatus']}, the new version is {status['appStatus']}"
+            )

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -6,7 +6,6 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 import posixpath
-import time
 from typing import Any, Dict, List, Optional
 
 import click

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -6,8 +6,10 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 import posixpath
+import time
 from typing import Any, Dict, List, Optional
 
+import click
 from requests import Session
 
 from .exceptions import ClientResponseError
@@ -65,7 +67,7 @@ def get_custom_app_by_name(session: Session, endpoint: str, app_name: str) -> Di
             message=f'Can\'t find custom application "{app_name}" by name.',
             url=error_url,
         )
-    return apps[0]
+    return next((app for app in apps if app['name'] == app_name))
 
 
 def get_custom_app_logs(session: Session, endpoint: str, app_id: str) -> Dict[str, Any]:
@@ -102,8 +104,23 @@ def check_starting_status(session: Session, status_url: str) -> str:
 
 def update_running_custom_app(
     session: Session, app_id: str, endpoint: str, payload: Dict[str, Any]
-) -> None:
+) -> Optional[str]:
     """Updates a running custom app's name / active app/ etc"""
+    click.echo("Editing app w/ ID: {}".format(app_id))
     url = posixpath.join(endpoint, f'customApplications/{app_id}/')
     response = session.patch(url, json=payload)
     handle_dr_response(response)
+    return response.headers.get('location')
+
+
+def wait_for_publish_to_complete(session: Session, status_url: str):
+    click.echo("Waiting for publish to complete, the app will be ready when the old version is stopped")
+    for _ in range(100):
+        response = session.get(status_url)
+        handle_dr_response(response)
+        status = response.json()
+        if status['oldAppStatus'] == 'stopped':
+            click.echo("New App is ready!")
+            return
+        else:
+            click.echo(f"The old version is {status['oldAppStatus']}, the new version is {status['appStatus']}")

--- a/drapps/publish.py
+++ b/drapps/publish.py
@@ -14,7 +14,8 @@ from requests import Session
 from drapps.helpers.custom_apps_functions import (
     get_custom_app_by_id,
     get_custom_app_by_name,
-    update_running_custom_app, wait_for_publish_to_complete,
+    update_running_custom_app,
+    wait_for_publish_to_complete,
 )
 from drapps.helpers.wrappers import api_endpoint, api_token
 

--- a/drapps/publish.py
+++ b/drapps/publish.py
@@ -14,7 +14,7 @@ from requests import Session
 from drapps.helpers.custom_apps_functions import (
     get_custom_app_by_id,
     get_custom_app_by_name,
-    update_running_custom_app,
+    update_running_custom_app, wait_for_publish_to_complete,
 )
 from drapps.helpers.wrappers import api_endpoint, api_token
 
@@ -43,12 +43,20 @@ from drapps.helpers.wrappers import api_endpoint, api_token
     type=click.STRING,
     help='Name or ID for the application to copy the application from.',
 )
+@click.option(
+    '--skip-wait',
+    is_flag=True,
+    show_default=True,
+    default=False,
+    help='Do not wait for ready status.',
+)
 def publish(
     application_to_be_updated: str,
     token: str,
     endpoint: str,
     name: Optional[str],
     source_application: Optional[str],
+    skip_wait: bool,
 ) -> None:
     """Updates a custom app, this covers the basic case of a new name
     and also the custom apps publishing work which is scoped for 10.2
@@ -71,9 +79,15 @@ def publish(
 
     if name:
         payload['name'] = name
-    update_running_custom_app(
+    location = update_running_custom_app(
         session=session,
         app_id=app_id,
         endpoint=endpoint,
         payload=payload,
     )
+    if not skip_wait:
+        wait_for_publish_to_complete(
+            session=session,
+            status_url=location,
+        )
+

--- a/drapps/publish.py
+++ b/drapps/publish.py
@@ -86,7 +86,7 @@ def publish(
         endpoint=endpoint,
         payload=payload,
     )
-    if not skip_wait:
+    if (not skip_wait) and location:
         wait_for_publish_to_complete(
             session=session,
             status_url=location,

--- a/drapps/publish.py
+++ b/drapps/publish.py
@@ -91,4 +91,3 @@ def publish(
             session=session,
             status_url=location,
         )
-

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.1.5
+version = 10.1.6

--- a/tests/cli/test_publish.py
+++ b/tests/cli/test_publish.py
@@ -84,7 +84,7 @@ def test_publish_app(
     )
 
     runner = CliRunner()
-    result = runner.invoke(publish, cli_args)
+    result = runner.invoke(publish, [*cli_args, '--skip-wait'])
     logger = logging.getLogger()
     if result.exit_code:
         logger.error(result.output)


### PR DESCRIPTION
With the new Custom Apps publishing functionality, the process of publishing an app may take a few (~3) minutes. Having the process be an async thing where you kick off a job, and wait for the job to be ready is a bad user experience because there's no way to know when your published app is ready, or making progress, or errored. 

This PR is coupled with a PR on our internal repo to add a URL to the publication (See that for more info please!) 