### PR TITLE
[APP-2916] use v{num} instead of script_generated_{num}

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -106,7 +106,7 @@ def create_new_custom_app_source_version(
         version_count = 0
 
     click.echo(f'Using {source_name} custom application source.')
-    version_label = f'script_generated_{version_count}'
+    version_label = f'v{version_count}'
     new_version = create_application_source_version(
         session, endpoint, app_source['id'], version_label
     )

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -106,7 +106,7 @@ def create_new_custom_app_source_version(
         version_count = 0
 
     click.echo(f'Using {source_name} custom application source.')
-    version_label = f'v{version_count}'
+    version_label = f'v{version_count +1 }'
     new_version = create_application_source_version(
         session, endpoint, app_source['id'], version_label
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.1.7
+version = 10.1.8

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -176,7 +176,7 @@ def test_create_from_project(
     )
     # request for creating new application source version
     custom_app_source_version_id = str(ObjectId())
-    source_version_data_matcher = matchers.json_params_matcher({'label': 'script_generated_0'})
+    source_version_data_matcher = matchers.json_params_matcher({'label': 'v0'})
     responses.post(
         f'{api_endpoint_env}/customApplicationSources/{custom_app_source_id}/versions/',
         json={'id': custom_app_source_version_id},

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -176,7 +176,7 @@ def test_create_from_project(
     )
     # request for creating new application source version
     custom_app_source_version_id = str(ObjectId())
-    source_version_data_matcher = matchers.json_params_matcher({'label': 'v0'})
+    source_version_data_matcher = matchers.json_params_matcher({'label': 'v1'})
     responses.post(
         f'{api_endpoint_env}/customApplicationSources/{custom_app_source_id}/versions/',
         json={'id': custom_app_source_version_id},


### PR DESCRIPTION
This should be consistent:

<img width="564" alt="Screenshot 2024-07-11 at 9 06 01 AM" src="https://github.com/datarobot/dr-apps/assets/90279826/7a3cfb41-80af-423d-b58f-8fbae1b103e4">
