### PR TITLE
[APP-2973] Fix check for publishing when app starts in a stopped state

### DIFF
--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -120,7 +120,7 @@ def wait_for_publish_to_complete(session: Session, status_url: str):
         response = session.get(status_url)
         handle_dr_response(response)
         status = response.json()
-        if status['oldAppStatus'] == 'stopped':
+        if status['oldAppStatus'] == 'stopped' and status['appStatus'] == 'running':
             click.echo("New App is ready!")
             return
         else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.1.8
+version = 10.2.0


### PR DESCRIPTION
The publication flow is:
Build new app --> Start new app --> Stop old app

and so the check was (erroneously) to wait for the old app to be fully stopped. This only makes sense if the app's initial state is `running`. If the app that's set to be published to starts as `paused` then the CLI will think the app has already published the new version, when in fact it has not. 
