### PR TITLE
[APP-3079] [App 3079] rely on `running` from status API, and remove usage of /status/ API

### DIFF
--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -5,8 +5,8 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
-import time
 import posixpath
+import time
 from typing import Any, Dict, List, Optional
 
 import click

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -5,6 +5,7 @@
 #  This is proprietary source code of DataRobot, Inc. and its affiliates.
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
+import time
 import posixpath
 from typing import Any, Dict, List, Optional
 
@@ -103,7 +104,7 @@ def check_starting_status(session: Session, status_url: str) -> str:
 
 def update_running_custom_app(
     session: Session, app_id: str, endpoint: str, payload: Dict[str, Any]
-) -> Optional[str]:
+):
     """Updates a running custom app's name / active app/ etc"""
     click.echo("Editing app w/ ID: {}".format(app_id))
     url = posixpath.join(endpoint, f'customApplications/{app_id}/')

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -109,24 +109,16 @@ def update_running_custom_app(
     url = posixpath.join(endpoint, f'customApplications/{app_id}/')
     response = session.patch(url, json=payload)
     handle_dr_response(response)
-    return response.headers.get('location')
 
 
-def wait_for_publish_to_complete(session: Session, status_url: str):
-    click.echo(
-        "Waiting for publish to complete, the app will be ready when the old version is stopped"
-    )
+def wait_for_app_to_be_running(session: Session, endpoint: str, app_id: str):
+    click.echo("Waiting for publish to complete.")
     for _ in range(100):
-        response = session.get(status_url)
-        handle_dr_response(response)
-        status = response.json()
-        if status['oldAppStatus'] == 'stopped' and status['appStatus'] == 'running':
+        app = get_custom_app_by_id(session=session, endpoint=endpoint, app_id=app_id)
+        if app['status'] == 'running':
             click.echo("New App is ready!")
             return
-        else:
-            click.echo(
-                f"The old version is {status['oldAppStatus']}, the new version is {status['appStatus']}"
-            )
+        time.sleep(5)
 
 
 def get_history_by_index(

--- a/drapps/helpers/custom_apps_functions.py
+++ b/drapps/helpers/custom_apps_functions.py
@@ -119,6 +119,9 @@ def wait_for_app_to_be_running(session: Session, endpoint: str, app_id: str):
         if app['status'] == 'running':
             click.echo("New App is ready!")
             return
+        elif app['status'] == 'failed':
+            click.echo("App failed to start.")
+            return
         time.sleep(5)
 
 

--- a/drapps/publish.py
+++ b/drapps/publish.py
@@ -16,7 +16,7 @@ from drapps.helpers.custom_apps_functions import (
     get_custom_app_by_name,
     get_history_by_index,
     update_running_custom_app,
-    wait_for_publish_to_complete,
+    wait_for_app_to_be_running,
 )
 from drapps.helpers.wrappers import api_endpoint, api_token
 
@@ -81,16 +81,17 @@ def publish(
 
     if name:
         payload['name'] = name
-    location = update_running_custom_app(
+    update_running_custom_app(
         session=session,
         app_id=app_id,
         endpoint=endpoint,
         payload=payload,
     )
-    if (not skip_wait) and location:
-        wait_for_publish_to_complete(
+    if not skip_wait:
+        wait_for_app_to_be_running(
             session=session,
-            status_url=location,
+            app_id=app_id,
+            endpoint=endpoint,
         )
 
 
@@ -139,14 +140,15 @@ def revert_publish(
         index=by - 1,
     )
 
-    location = update_running_custom_app(
+    update_running_custom_app(
         session=session,
         app_id=app_id,
         endpoint=endpoint,
         payload={'customApplicationSourceVersionId': history['sourceVersionId']},
     )
-    if (not skip_wait) and location:
-        wait_for_publish_to_complete(
+    if not skip_wait:
+        wait_for_app_to_be_running(
             session=session,
-            status_url=location,
+            endpoint=endpoint,
+            app_id=app_id,
         )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.2.0
+version = 10.2.1

--- a/tests/cli/test_publish.py
+++ b/tests/cli/test_publish.py
@@ -138,8 +138,14 @@ def test_revert_publish_by_index(api_token_env, api_endpoint_env, use_name_for_s
         status=204,
     )
 
+    responses.get(
+        f'{api_endpoint_env}/customApplications/{app_id}/',
+        json={'status': 'running'},
+        match=[auth_matcher],
+    )
+
     runner = CliRunner()
-    result = runner.invoke(revert_publish, [*cli_args, '--by', index, '--skip-wait'])
+    result = runner.invoke(revert_publish, [*cli_args, '--by', index])
 
     logger = logging.getLogger()
     if result.exit_code:


### PR DESCRIPTION
It doesn't make sense for the DataRobot application to use the `app.status` attribute and the CLI to use the `/status/` API

We should remove this API before making things GA so we don't have an unused API