### PR TITLE
[APP-3259] Add logic for creating apps w/ custom num instances or resources

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -390,8 +390,24 @@ def parse_env_vars(ctx, param, value):
 @click.option(
     '--cpu-size',
     required=False,
-    type=click.Choice(['nano', 'micro', 'small', 'medium', 'large', 'xlarge', '2xlarge']),
+    type=click.Choice(['2xsmall', 'xsmall', 'small', 'medium', 'large', 'xlarge', '2xlarge']),
     default='small',
+    help=(
+        # This string must be 39 characters because it gets post-processed
+        ''.join(
+            "{:<14} | {:<10} | {:<13}".format(*t)
+            for t in [
+                ('Option Name', 'CPUs', 'RAM'),
+                ('2xsmall', 1, '128 MB'),
+                ('xsmall', 1, '256 MB'),
+                ('small', 1, '512 MB'),
+                ('medium', 1, '1 GB'),
+                ('large', 2, '1.5 GB'),
+                ('xlarge', 2, '2 GB'),
+                ('2xlarge', 2, '3 GB'),
+            ]
+        )
+    ),
 )
 @click.option(
     '--skip-wait',

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -23,6 +23,7 @@ from .helpers.custom_app_sources_functions import (
     get_custom_app_source_by_name,
     get_custom_app_source_versions_list,
     update_application_source_version,
+    update_cpu_size,
     update_num_replicas,
     update_runtime_params,
 )
@@ -175,6 +176,7 @@ def configure_custom_app_source_version(
     base_env_version_id: str,
     runtime_params: List[Dict],
     replicas: int,
+    cpu_size: str,
 ) -> None:
     payload: Dict[str, Any] = {'baseEnvironmentVersionId': base_env_version_id}
     project_files = get_project_files_list(project)
@@ -215,6 +217,14 @@ def configure_custom_app_source_version(
             version_id=custom_app_source_version_id,
             replicas=replicas,
         )
+        # Add CPU Tee-Shirt Size
+        update_cpu_size(
+            session=session,
+            endpoint=endpoint,
+            source_id=custom_app_source_id,
+            version_id=custom_app_source_version_id,
+            cpu_size=cpu_size,
+        )
         # Finally, add runtime params
         update_runtime_params(
             session=session,
@@ -233,6 +243,7 @@ def create_app_from_project(
     app_name: str,
     runtime_params: List[Dict],
     replicas: int,
+    cpu_size: str,
 ) -> Dict[str, Any]:
     base_env_version_id = get_base_env_version(session, endpoint, base_env)
     source_name = f'{app_name}Source'
@@ -248,6 +259,7 @@ def create_app_from_project(
         base_env_version_id=base_env_version_id,
         runtime_params=runtime_params,
         replicas=replicas,
+        cpu_size=cpu_size,
     )
     app_payload = {'name': app_name, 'applicationSourceId': custom_app_source_id}
     click.echo(f'Starting {app_name} custom application.')
@@ -378,6 +390,12 @@ def parse_env_vars(ctx, param, value):
     help='Number of replicas to be created.',
 )
 @click.option(
+    '--cpu-size',
+    required=False,
+    type=click.Choice(['nano', 'micro', 'small', 'medium', 'large', 'xlarge', '2xlarge']),
+    default='small',
+)
+@click.option(
     '--skip-wait',
     is_flag=True,
     show_default=True,
@@ -412,6 +430,7 @@ def create(
     numericenvvar: Optional[Dict[str, str]],
     application_name: str,
     replicas: int,
+    cpu_size: str,
 ) -> None:
     """
     Creates new custom application from docker image or base environment.
@@ -445,6 +464,7 @@ def create(
             app_name=application_name,
             runtime_params=runtime_params,
             replicas=replicas,
+            cpu_size=cpu_size,
         )
 
     if skip_wait or not app_data.get('statusUrl'):

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -209,7 +209,6 @@ def configure_custom_app_source_version(
 
             payload = {}
             progress.update(len(file_chunk))
-        # Add replicas to request (If we specified any)
         update_num_replicas(
             session=session,
             endpoint=endpoint,
@@ -217,7 +216,6 @@ def configure_custom_app_source_version(
             version_id=custom_app_source_version_id,
             replicas=replicas,
         )
-        # Add CPU Tee-Shirt Size
         update_cpu_size(
             session=session,
             endpoint=endpoint,

--- a/drapps/helpers/custom_app_sources_functions.py
+++ b/drapps/helpers/custom_app_sources_functions.py
@@ -96,6 +96,19 @@ def update_runtime_params(
         handle_dr_response(response)
 
 
+def update_num_replicas(
+    session: Session,
+    endpoint: str,
+    source_id: str,
+    version_id: str,
+    replicas: int,
+):
+    url = posixpath.join(endpoint, f"customApplicationSources/{source_id}/versions/{version_id}/")
+    form_data = {"resources": (None, f'{{"replicas":{replicas}}}', 'application/json')}
+    rsp = session.patch(url, files=form_data)
+    handle_dr_response(rsp)
+
+
 def get_custom_app_source_versions_list(
     session: Session, endpoint: str, source_id: str
 ) -> List[Dict[str, Any]]:

--- a/drapps/helpers/custom_app_sources_functions.py
+++ b/drapps/helpers/custom_app_sources_functions.py
@@ -109,6 +109,19 @@ def update_num_replicas(
     handle_dr_response(rsp)
 
 
+def update_cpu_size(
+    session: Session,
+    endpoint: str,
+    source_id: str,
+    version_id: str,
+    cpu_size: str,
+):
+    url = posixpath.join(endpoint, f"customApplicationSources/{source_id}/versions/{version_id}/")
+    form_data = {"resources": (None, f'{{"resourceLabel":"cpu.{cpu_size}"}}', 'application/json')}
+    rsp = session.patch(url, files=form_data)
+    handle_dr_response(rsp)
+
+
 def get_custom_app_source_versions_list(
     session: Session, endpoint: str, source_id: str
 ) -> List[Dict[str, Any]]:

--- a/drapps/helpers/custom_app_sources_functions.py
+++ b/drapps/helpers/custom_app_sources_functions.py
@@ -116,6 +116,10 @@ def update_cpu_size(
     version_id: str,
     cpu_size: str,
 ):
+    if cpu_size == '2xsmall':
+        cpu_size = 'nano'
+    elif cpu_size == 'xsmall':
+        cpu_size = 'micro'
     url = posixpath.join(endpoint, f"customApplicationSources/{source_id}/versions/{version_id}/")
     form_data = {"resources": (None, f'{{"resourceLabel":"cpu.{cpu_size}"}}', 'application/json')}
     rsp = session.patch(url, files=form_data)

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.2.2
+version = 10.2.3

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -143,7 +143,7 @@ def test_create_from_project(
         So rather than use a form-data matcher, it makes more sense to just check it after the test run.
     """
     n_instances = 2
-    desired_cpu_size = 'large'
+    desired_cpu_size = '2xsmall'
     app_name = 'new_app'
     project_folder = 'project-folder'
     ee_name = 'ExecutionEnv'
@@ -316,9 +316,7 @@ def test_create_from_project(
         and 'resourceLabel' in call.request.body.decode('utf-8')  # noqa: W503
     ]
     assert len(cpu_sz_requests) == 1
-    assert (
-        f'{{"resourceLabel":"cpu.{desired_cpu_size}"}}'.encode() in cpu_sz_requests[0].request.body
-    )
+    assert f'{{"resourceLabel":"cpu.nano"}}'.encode() in cpu_sz_requests[0].request.body
 
 
 @pytest.mark.usefixtures('api_endpoint_env', 'api_token_env')

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -316,7 +316,8 @@ def test_create_from_project(
         and 'resourceLabel' in call.request.body.decode('utf-8')  # noqa: W503
     ]
     assert len(cpu_sz_requests) == 1
-    assert f'{{"resourceLabel":"cpu.nano"}}'.encode() in cpu_sz_requests[0].request.body
+    # NOTE: We have to map 2xsmall -> nano
+    assert '{"resourceLabel":"cpu.nano"}'.encode() in cpu_sz_requests[0].request.body
 
 
 @pytest.mark.usefixtures('api_endpoint_env', 'api_token_env')


### PR DESCRIPTION
This provides functionality to add:
1. The number of specified replicas
2. The CPU size of the running container

Via a command like:
```
drapps create EXAMPLE_APP --path examples/myExample/ --base-env MyAwesomeEnv --replicas 2 --cpu-size large
```
> [!TIP]
> The sizes correspond to:
> | name | CPU  | RAM |
> | ----| -------------- | ------|
> | nano| 1 CPU | 128MB |
> | micro | 1 CPU | 256MB |
> | small | 1 CPU | 512MB | 
> | medium | 1 CPU | 1GB |
> | large | 2 CPU | 1.5GB |
> | xlarge | 2 CPU | 2GB |
> | 2xlarge | 2 CPU | 3GB |

