### PR TITLE
[APP-3369] Make the dockerfile zip path required

### DIFF
--- a/drapps/env.py
+++ b/drapps/env.py
@@ -29,7 +29,7 @@ from .helpers.wrappers import api_endpoint, api_token
 @click.option(
     '-i',
     '--dockerfilezip',
-    required=False,
+    required=True,
     type=click.Path(exists=True, dir_okay=False, resolve_path=True, path_type=Path),
     help='Path to tar archive which contains dockerfile',
 )

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.2.3
+version = 10.2.4


### PR DESCRIPTION
The dockerfile path for `drapps create-env` is set as a not required argument, BUT in the type hinting it's not listed as an `Optional[Path]`:
https://github.com/datarobot/dr-apps/blob/b0615531ea753cd2bc01dbc6eac9f70449734be7/drapps/env.py#L45

In the upload logic there is no None check. :
https://github.com/datarobot/dr-apps/blob/b0615531ea753cd2bc01dbc6eac9f70449734be7/drapps/create.py#L291-L292
so the code as-it-is assumes there's never a None supplied.

Furthermore, this logic cannot work fully with no docker context, so it doesn't make sense to support None checking.