### PR TITLE
[APP-3485] Allow apps CLI to manage external sharing

### DIFF
--- a/drapps/__main__.py
+++ b/drapps/__main__.py
@@ -10,6 +10,7 @@ from click import Group
 
 from drapps.create import create
 from drapps.env import create_env
+from drapps.externalshare import external_share
 from drapps.logs import logs
 from drapps.ls import ls
 from drapps.publish import publish, revert_publish
@@ -20,7 +21,7 @@ help_text = (
     'You can use drapps COMMAND --help for getting more info about command.'
 )
 drapps = Group(
-    commands=[create, ls, logs, terminate, create_env, publish, revert_publish],
+    commands=[create, ls, logs, terminate, create_env, publish, revert_publish, external_share],
     help=help_text,
 )
 

--- a/drapps/externalshare.py
+++ b/drapps/externalshare.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Any
+from typing import Any, List, Optional
 
 import click
 from bson import ObjectId
@@ -55,7 +55,7 @@ def external_share(
             current_external_users.update(set(add_external_user))
         if remove_external_user:
             current_external_users.difference_update(set(remove_external_user))
-        payload['externalAccessEnabled'] = list(current_external_users)
+        payload['externalAccessRecipients'] = list(current_external_users)
 
     update_running_custom_app(
         session=session,

--- a/drapps/externalshare.py
+++ b/drapps/externalshare.py
@@ -1,0 +1,65 @@
+from typing import List, Optional, Any
+
+import click
+from bson import ObjectId
+from requests import Session
+
+from .helpers.custom_apps_functions import (
+    get_custom_app_by_id,
+    get_custom_app_by_name,
+    update_running_custom_app,
+)
+from .helpers.wrappers import api_endpoint, api_token
+
+
+@click.command()
+@api_token
+@api_endpoint
+@click.argument('application_name', type=click.STRING, required=True)
+@click.option('--set-external-sharing', type=click.BOOL, default=None)
+@click.option(
+    '--add-external-user',
+    multiple=True,
+    required=False,
+    type=click.STRING,
+)
+@click.option(
+    '--remove-external-user',
+    multiple=True,
+    required=False,
+    type=click.STRING,
+)
+def external_share(
+    token: str,
+    endpoint: str,
+    set_external_sharing: Optional[bool],
+    application_name: str,
+    add_external_user: List[str],
+    remove_external_user: List[str],
+):
+    session = Session()
+    session.headers.update({'Authorization': f'Bearer {token}'})
+    payload: dict[str, Any] = dict()
+    if ObjectId.is_valid(application_name):
+        app = get_custom_app_by_id(session, endpoint, app_id=application_name)
+        app_id = application_name
+    else:
+        app = get_custom_app_by_name(session, endpoint, app_name=application_name)
+        app_id = app['id']
+
+    if set_external_sharing is not None:
+        payload['externalAccessEnabled'] = set_external_sharing
+    if add_external_user or remove_external_user:
+        current_external_users = set(app.get('externalAccessRecipients', []))
+        if add_external_user:
+            current_external_users.update(set(add_external_user))
+        if remove_external_user:
+            current_external_users.difference_update(set(remove_external_user))
+        payload['externalAccessEnabled'] = list(current_external_users)
+
+    update_running_custom_app(
+        session=session,
+        app_id=app_id,
+        endpoint=endpoint,
+        payload=payload,
+    )

--- a/drapps/ls.py
+++ b/drapps/ls.py
@@ -36,6 +36,10 @@ def _date_fetcher(field_name: str, entity) -> str:
         return date.date().isoformat()
 
 
+def _list_str_fetcher(field_name: str, entity) -> str:
+    return ','.join(entity.get(field_name))
+
+
 def format_table(
     data: List[Dict[str, Any]], data_fetchers: Dict[str, Callable[[Dict[str, Any]], str]]
 ) -> str:
@@ -58,6 +62,8 @@ def list_apps(session: Session, endpoint: str, id_only: bool) -> str:
         'status': partial(_string_fetcher, 'status'),
         'updated': partial(_date_fetcher, 'updatedAt'),
         'URL': partial(_string_fetcher, 'applicationUrl'),
+        'external sharing': partial(_string_fetcher, 'externalAccessEnabled'),
+        'external sharing recipients': partial(_list_str_fetcher, 'externalAccessRecipients'),
     }
     return format_table(apps, data_fetchers)  # type: ignore[arg-type]
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.2.4
+version = 10.2.5

--- a/tests/cli/test_externalshare.py
+++ b/tests/cli/test_externalshare.py
@@ -45,7 +45,7 @@ def test_set_external_sharing(
         'externalAccessRecipients': [
             'existing.user.1@datarobot.com',
             'existing.user.2@datarobot.com',
-            '@enron.com',
+            '@some-external-domain.com',
         ],
     }
     expected_external_access_recipients = set(app['externalAccessRecipients'])

--- a/tests/cli/test_externalshare.py
+++ b/tests/cli/test_externalshare.py
@@ -1,0 +1,96 @@
+import logging
+
+import pytest
+import responses
+from bson import ObjectId
+from click.testing import CliRunner
+from responses import matchers
+
+from drapps.externalshare import external_share
+
+logger = logging.getLogger()
+
+
+@pytest.mark.parametrize('app_id', [str(ObjectId())])
+@responses.activate
+@pytest.mark.parametrize('use_name', [True, False])
+@pytest.mark.parametrize('allow_external_sharing', [True, False])
+@pytest.mark.parametrize('users_to_add', [['new.user.1@datarobot.com', 'new.user.2@datarobot.com']])
+@pytest.mark.parametrize('users_to_remove', ['@enron.com'])
+def test_set_external_sharing(
+    api_token_env,
+    api_endpoint_env,
+    app_id,
+    allow_external_sharing,
+    use_name,
+    users_to_add,
+    users_to_remove,
+):
+    """
+    Tests two core functionalities of external sharing:
+    1. Managing whether it is enabled
+    2. Managing external sharing users
+
+    The external sharing API takes in the external sharing list (externalAccessRecipients) as one entity.
+    So if you want to add a user to the external sharing list, and you already have 100 users
+    you'll need to send the "new" list with the 100 old users and the 1 new user.
+
+    In this CLI I want to make this easier to work with, so instead of having the user supply
+    the whole list - which would be unpleasant to scale to 100+ users :) they just supply the changes.
+    In this case, we query DataRobot for the current list of users, and just make the changes.
+    """
+    app = {
+        'id': app_id,
+        'name': "My Externally Shared App",
+        'externalAccessRecipients': [
+            'existing.user.1@datarobot.com',
+            'existing.user.2@datarobot.com',
+            '@enron.com',
+        ],
+    }
+    expected_external_access_recipients = set(app['externalAccessRecipients'])
+    expected_external_access_recipients.update(users_to_add)
+    expected_external_access_recipients.remove(users_to_remove)
+    auth_matcher = matchers.header_matcher({'Authorization': f'Bearer {api_token_env}'})
+    responses.patch(
+        f'{api_endpoint_env}/customApplications/{app_id}/',
+        json={
+            'externalAccessEnabled': allow_external_sharing,
+            'externalAccessRecipients': list(expected_external_access_recipients),
+        },
+        match=[auth_matcher],
+    )
+    if use_name:
+        app_list_url = f'{api_endpoint_env}/customApplications/'
+        # check that name filter was used
+        params_matcher = matchers.query_param_matcher({'name': app['name']})
+        responses.get(
+            app_list_url,
+            json={'count': 1, 'data': [app]},
+            match=[auth_matcher, params_matcher],
+        )
+    else:
+        responses.get(
+            f'{api_endpoint_env}/customApplications/{app_id}/',
+            json=app,
+            match=[auth_matcher],
+        )
+
+    # NOTE: If you do cli_args = [app_id, '--set-external-sharing', allow_external_sharing']
+    # You get a strange dictionary error for the `True` case.
+    cli_args = [
+        app['name'] if use_name else app_id,
+        '--set-external-sharing',
+        allow_external_sharing,
+    ]
+    for user in users_to_add:
+        cli_args.extend(['--add-external-user', user])
+    for user in users_to_remove:
+        cli_args.extend(['--remove-external-user', user])
+    runner = CliRunner()
+    result = runner.invoke(external_share, args=cli_args)
+    if result.exit_code:
+        logger.error(result.output)
+    else:
+        logger.info(result.output)
+    assert result.exit_code == 0, result.exception

--- a/tests/cli/test_externalshare.py
+++ b/tests/cli/test_externalshare.py
@@ -16,7 +16,7 @@ logger = logging.getLogger()
 @pytest.mark.parametrize('use_name', [True, False])
 @pytest.mark.parametrize('allow_external_sharing', [True, False])
 @pytest.mark.parametrize('users_to_add', [['new.user.1@datarobot.com', 'new.user.2@datarobot.com']])
-@pytest.mark.parametrize('users_to_remove', ['@enron.com'])
+@pytest.mark.parametrize('users_to_remove', ['@some-external-domain.com'])
 def test_set_external_sharing(
     api_token_env,
     api_endpoint_env,

--- a/tests/cli/test_ls.py
+++ b/tests/cli/test_ls.py
@@ -29,6 +29,8 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
                 'envVersionId': '659964572522de6a026de5cf',
                 # make it current day, so we see time in results
                 'updatedAt': datetime.today().replace(hour=11, minute=59, second=59).isoformat(),
+                'externalAccessEnabled': True,
+                'externalAccessRecipients': ['ben@datarobot.com', 'ben2@datarobot.com'],
             },
             {
                 'id': '659964182522de6a026de5cd',
@@ -37,6 +39,8 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
                 'applicationUrl': 'http://ho.st/custom_applications/659964182522de6a026de5cd/',
                 'envVersionId': '659964572522de6a026de5d0',
                 'updatedAt': '2023-11-12 14:12:46.092000',
+                'externalAccessEnabled': False,
+                'externalAccessRecipients': [],
             },
             {
                 'id': '659964382522de6a026de5ce',
@@ -45,6 +49,8 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
                 'applicationUrl': 'http://ho.st/custom_applications/659964382522de6a026de5ce/',
                 'envVersionId': '659964572522de6a026de5d1',
                 'updatedAt': '2024-01-28 14:12:46.092000',
+                'externalAccessEnabled': False,
+                'externalAccessRecipients': [],
             },
         ],
     }
@@ -54,11 +60,11 @@ def test_ls_apps(api_endpoint_env, api_token_env, ids_only):
         )
     else:
         expected_output = (
-            'id                        name    status    updated     URL\n'
-            '------------------------  ------  --------  ----------  ----------------------------------------------------------\n'
-            '65980d79eea4fd0eddd59bba  App 1   running   11:59:59    http://ho.st/custom_applications/65980d79eea4fd0eddd59bba/\n'
-            '659964182522de6a026de5cd  App 2   running   2023-11-12  http://ho.st/custom_applications/659964182522de6a026de5cd/\n'
-            '659964382522de6a026de5ce  App 3   running   2024-01-28  http://ho.st/custom_applications/659964382522de6a026de5ce/\n'
+            'id                        name    status    updated     URL                                                         external sharing    external sharing recipients\n'
+            '------------------------  ------  --------  ----------  ----------------------------------------------------------  ------------------  ------------------------------------\n'
+            '65980d79eea4fd0eddd59bba  App 1   running   11:59:59    http://ho.st/custom_applications/65980d79eea4fd0eddd59bba/  True                ben@datarobot.com,ben2@datarobot.com\n'
+            '659964182522de6a026de5cd  App 2   running   2023-11-12  http://ho.st/custom_applications/659964182522de6a026de5cd/  False\n'
+            '659964382522de6a026de5ce  App 3   running   2024-01-28  http://ho.st/custom_applications/659964382522de6a026de5ce/  False\n'
         )
 
     app_list_url = f'{api_endpoint_env}/customApplications/'


### PR DESCRIPTION
The external sharing (email sharing) doesn't have any implementation in the datarobot apps CLI, so CLI only users have to either hand-roll requests or go to the UI to manage external sharing. 

This PR adds functionality in tandem with DOC-7233 to allow us to:
0. Toggle external sharing on/off
1. Add external users
2. Remove external users
3. View the external sharing / external sharing users. 


Example Usages:
```
Enable external sharing for an app:
> drapps external-share 6728fce3a2ad2d97d14b04aa --set-external-sharing True

Enable external sharing (by ID) for my account
> drapps external-share 6728fce3a2ad2d97d14b04aa --add-external-user ben.cutler@datarobot.com

Enable external sharing (by name) for my account
> drapps external-share MyAwesomeApp --add-external-user ben.cutler@datarobot.com

Add two users from external sharing:
> drapps external-share MyAwesomeApp --add-external-user ben.cutler@datarobot.com  --add-external-user benjamin.cutler@datarobot.com 

Add one user and remove one from external sharing
> drapps external-share MyAwesomeApp --add-external-user ben.cutler@datarobot.com  --remove-external-user raul@datarobot.com 
```

>[!NOTE]
> There is no dependency on adjusting the external sharing list and adjusting whether external sharing is turned on. 
> If you like you can dial in your external sharing list, then enable external sharing or do it in the reverse order where you turn on sharing then add and remove members as you like. 