### PR TITLE
[APP-2887] Replace streamlit-wordcloud and bump all dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,10 +17,11 @@ pip install git+https://github.com/datarobot/dr-apps
 ### For contributors
 
 To install the DRApps CLI tool, clone this
-respository and then install package by running the following command:
+repository and then install the package by running the following command:
 
 ```sh
-python setup.py install
+# If your environment does not already have `build` then run `pip install build` first
+python -m build
 ```
 
 ## For Windows Users
@@ -31,7 +32,7 @@ For Windows users, you may need to interface with the DR Custom Apps CLI via mod
 python -m drapps <your_commands_here>
 ```
 
-If you have issues entering words with spaces ( eg: `-e "[Experimental] Python 3.9 Streamlit"` )
+If you have issues entering words with spaces ( eg: `-e "[DataRobot] Python 3.12 Applications Base"` )
 then you may find that using ids is a little easier.
 
 ## Use the DRApps CLI
@@ -176,18 +177,17 @@ Options:
 
 ### Create a new Execution Environment
 
-It may be the case that your version of DataRobot (eg Single Tenant SAAS or On-Prem) was not shipped with the `[Experimental] Python 3.9 Streamlit`
+It may be the case that your version of DataRobot (eg Single Tenant SAAS or On-Prem) was not shipped with the `[DataRobot] Python 3.12 Applications Base`
 or that you want to make a new execution environment for your apps (eg you want to make a Flask app, or you want your base docker image
 to have some packages installed in it that don't come standard
 
-First you will need to make a dockerfile. For the default `[Experimental] Python 3.9 Streamlit` env we use:
+First you will need to make a dockerfile. For the default `[DataRobot] Python 3.12 Applications Base` env we use:
 
 ```dockerfile
-FROM python:3.9-slim
+FROM python:3.12-slim
 
-WORKDIR /app
-
-RUN pip3 install --no-cache-dir 'streamlit==1.31.0' 'pillow==10.3.0' 'datarobot==3.0.2' 'plotly==5.13.0' 'streamlit-wordcloud==0.1.0' 'kaleido==0.2.1' 'tabulate==0.9.0' 'altair<5'
+# This makes print statements show up in the logs API
+ENV PYTHONUNBUFFERED=1
 
 WORKDIR /opt/code
 
@@ -198,7 +198,7 @@ That dockerfile will then need to be archived into a zip file. For this example 
 Once you have the file zipped, and you open a terminal in the directory you can use the apps CLI:
 
 ```
-drapps create-env --dockerfilezip dockerfile.zip --name "[Experimental] Python 3.9 Streamlit"
+drapps create-env --dockerfilezip dockerfile.zip --name "[DataRobot] Python 3.12 Applications Base"
 ```
 
 ## Deploy an example app
@@ -207,7 +207,7 @@ To test this, deploy an example Streamlit app using the following command from
 the root directory of this repo:
 
 ```sh
-drapps create -t <your_api_token> -e "[Experimental] Python 3.9 Streamlit" -p ./demo-streamlit DemoApp
+drapps create -t <your_api_token> -e "[DataRobot] Python 3.12 Applications Base" -p ./demo-streamlit DemoApp
 ```
 
 This example script works as follows:

--- a/examples/prediction-demo/.streamlit/config.toml
+++ b/examples/prediction-demo/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+base="dark"

--- a/examples/prediction-demo/dr-logo.svg
+++ b/examples/prediction-demo/dr-logo.svg
@@ -1,16 +1,4 @@
-import base64
-
-
-def datarobot_logo(icon_color='#181D21', data_color='#181D21', robot_color='#428BCA'):
-    """
-    A little confusing here:
-     🤖DataRobot
-     🤖 => icon_color
-     Data => data_color
-     Robot => robot_color
-    """
-
-    datarobot_svg = f"""<svg width="120" height="18" viewBox="0 0 120 18" fill="none" xmlns="http://www.w3.org/2000/svg">
+<svg width="120" height="18" viewBox="0 0 120 18" fill="none" xmlns="http://www.w3.org/2000/svg">
     <path d="M9.33367 16.0003H0V18H9.33367V16.0003Z" fill="white"/>
     <path d="M14.0004 14.0005H9.33361V16.0003H14.0004V14.0005Z" fill="white"/>
     <path d="M9.33367 12.0008H0V14.0005H9.33367V12.0008Z" fill="white"/>
@@ -39,6 +27,3 @@ def datarobot_logo(icon_color='#181D21', data_color='#181D21', robot_color='#428
     <path d="M37.5284 14.1826C38.8795 12.9763 39.5655 11.2332 39.5655 9.00478C39.5655 6.77637 38.9005 5.07064 37.5284 3.84093C36.1634 2.62055 34.362 2.00219 32.1732 2.00219H28.1667V16.0027H32.1732C34.4133 16.0027 36.1657 15.4077 37.5284 14.185V14.1826ZM30.1758 3.81059H32.2129C35.58 3.81059 37.5121 5.70299 37.5121 9.00478C37.5121 12.3066 35.615 14.164 32.3016 14.199V14.2036H30.1758V3.81059Z"
           fill="white"/>
 </svg>
-"""
-    newline = '\n'
-    return f"""<img src="data:image/svg+xml;base64,{base64.encodebytes(datarobot_svg.encode()).decode().replace(newline, "")}" alt="SVG Image">"""

--- a/examples/prediction-demo/dr_streamlit/caches.py
+++ b/examples/prediction-demo/dr_streamlit/caches.py
@@ -39,11 +39,11 @@ def initialize_and_get_feature_impact(
     try:
         return get_feature_impact()
     except ClientError as ce:
-        if 'No feature impact data found for model' in ce.json['message']:
+        if 'message' in ce.json and 'No feature impact data found for model' in ce.json['message']:
             fi_job = model.request_feature_impact()
             fi_job.wait_for_completion()
             return get_feature_impact()
-        elif 'Feature Impact is in progress' in ce.json['message']:
+        elif 'message' in ce.json and 'Feature Impact is in progress' in ce.json['message']:
             fi_job = FeatureImpactJob.get(project_id, ce.json['jobId'], with_metadata=False)
             fi_job.wait_for_completion()
             return get_feature_impact()

--- a/examples/prediction-demo/dr_streamlit/create_prediction.py
+++ b/examples/prediction-demo/dr_streamlit/create_prediction.py
@@ -87,7 +87,7 @@ def create_prediction_form(
         if v:
             if use_batch_prediction_api:
                 return submit_batch_prediction(
-                    deployment, pandas.DataFrame.from_dict(pred), max_explanations
+                    deployment.id, pandas.DataFrame.from_dict(pred), max_explanations
                 )
             else:
                 return submit_prediction(

--- a/examples/prediction-demo/dr_streamlit/feature_impact.py
+++ b/examples/prediction-demo/dr_streamlit/feature_impact.py
@@ -61,7 +61,7 @@ def derived_features_chart(
             height=height,
             width=width,
         )
-        return st.plotly_chart(fig)
+        return st.plotly_chart(fig, use_container_width=True)
     else:
         feature_impact = _get_aggregated_feature_impact_data(
             project_id=project_id, model_id=model_id
@@ -75,4 +75,4 @@ def derived_features_chart(
             .mark_bar()
             .encode(y=alt.Y('featureName', sort='-x'), x=alt.X('impactNormalized'))
         )
-        return st.altair_chart(c)
+        return st.altair_chart(c, use_container_width=True)

--- a/examples/prediction-demo/dr_streamlit/predictor.py
+++ b/examples/prediction-demo/dr_streamlit/predictor.py
@@ -8,7 +8,7 @@ import streamlit as st
 from datarobot import TARGET_TYPE, BatchPredictionJob, Deployment, Project
 from datarobot.client import Client, get_client
 
-from .caches import get_model
+from .caches import get_model, get_deployment
 
 
 def is_deployment_serverless(deployment: Deployment) -> bool:
@@ -86,7 +86,8 @@ def _camelCase_keys_to_snake_case_keys(data: Union[Dict[str, Any], List]):
 
 
 @st.cache_data
-def submit_batch_prediction(deployment: Deployment, df: pd.DataFrame, max_explanations: int):
+def submit_batch_prediction(deployment_id: str, df: pd.DataFrame, max_explanations: int):
+    deployment = get_deployment(deployment_id)
     [_, result] = BatchPredictionJob.score_pandas(
         deployment=deployment,
         df=df,

--- a/examples/prediction-demo/dr_streamlit/select_box.py
+++ b/examples/prediction-demo/dr_streamlit/select_box.py
@@ -46,7 +46,7 @@ def text_feature_dropdown_menu(project_id: str) -> str:
 
 @st.cache_data
 def _get_models(project_id: str) -> List[str]:
-    return [model.id for model in Project(project_id).get_models()]
+    return [model.id for model in Project(project_id).get_model_records()]
 
 
 def project_model_dropdown(project_id: str) -> str:

--- a/examples/prediction-demo/dr_streamlit/wordcloud.py
+++ b/examples/prediction-demo/dr_streamlit/wordcloud.py
@@ -1,8 +1,8 @@
 from typing import Any, Dict, Optional
 
-import wordcloud
 import matplotlib.pyplot as plt
 import streamlit as st
+import wordcloud
 from datarobot import Model
 from datarobot.errors import ClientError
 from datarobot.models.word_cloud import WordCloud
@@ -17,12 +17,12 @@ def _get_word_cloud_data(project_id, model_id, exclude_stop_words=False) -> Word
 
 
 def wordcloud_chart(
-        project_id,
-        model_id,
-        specified_class: Optional[str] = None,
-        selected_feature: Optional[str] = None,
-        exclude_stop_words: bool = False,
-        top_values: Optional[int] = None,
+    project_id,
+    model_id,
+    specified_class: Optional[str] = None,
+    selected_feature: Optional[str] = None,
+    exclude_stop_words: bool = False,
+    top_values: Optional[int] = None,
 ) -> Dict[str, Any]:
     """
 
@@ -54,14 +54,12 @@ def wordcloud_chart(
     if top_values:
         word_cloud_object = WordCloud(word_cloud_object.most_important(top_values))
 
-    # Choose a weight attribute for the word cloud, e.g., frequency or count
     word_frequencies = {item["ngram"]: item["frequency"] for item in word_cloud_object.ngrams if
                         not item["is_stopword"]}
 
     cloud = wordcloud.WordCloud(background_color='#0e1117', width=1600, height=800,
                                 random_state=42).generate_from_frequencies(word_frequencies)
 
-    # Display the word cloud
     fig, ax = plt.subplots(figsize=(12, 6), dpi=150)
     ax.imshow(cloud, interpolation='bilinear')
     ax.axis('off')

--- a/examples/prediction-demo/dr_streamlit/wrappers.py
+++ b/examples/prediction-demo/dr_streamlit/wrappers.py
@@ -7,6 +7,8 @@ def chart_with_error_backup(chart_func):
         try:
             return chart_func(*args, **kwargs)
         except ClientError as ce:
-            return st.error(ce.json['message'])
+            if 'message' in ce.json:
+                return st.error(ce.json['message'])
+            raise
 
     return wrapper

--- a/examples/prediction-demo/requirements.txt
+++ b/examples/prediction-demo/requirements.txt
@@ -1,8 +1,8 @@
-streamlit == 1.35.0
-datarobot==3.4.0
-plotly==5.13.0
-streamlit-wordcloud==0.1.0
+streamlit==1.40.0
+datarobot==3.5.2
+plotly==5.24.1
 kaleido==0.2.1
 tabulate==0.9.0
-altair<5
-pillow==10.3.0
+altair==5.4.1
+pillow==11.0.0
+wordcloud>=1.9.4

--- a/examples/prediction-demo/start-app.sh
+++ b/examples/prediction-demo/start-app.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export projectid=<projectid>
-export deploymentid=<deploymentid>
+export projectid=6710e5f7759307e559239e92
+export deploymentid=66a0b4c10339206299eeddaf
 export token="$DATAROBOT_API_TOKEN"
 export endpoint="$DATAROBOT_ENDPOINT"
 streamlit run --server.port 8080 streamlit_app.py

--- a/examples/prediction-demo/start-app.sh
+++ b/examples/prediction-demo/start-app.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 
-export projectid=6710e5f7759307e559239e92
-export deploymentid=66a0b4c10339206299eeddaf
+export projectid=<projectid>
+export deploymentid=<deploymentid>
 export token="$DATAROBOT_API_TOKEN"
 export endpoint="$DATAROBOT_ENDPOINT"
 streamlit run --server.port 8080 streamlit_app.py

--- a/examples/prediction-demo/streamlit_app.py
+++ b/examples/prediction-demo/streamlit_app.py
@@ -4,6 +4,7 @@ import pandas as pd
 import streamlit as st
 from datarobot import TARGET_TYPE, Client
 from datarobot.client import set_client
+
 from dr_streamlit import (
     create_prediction_form,
     derived_features_chart,
@@ -16,10 +17,10 @@ from dr_streamlit import (
     text_feature_dropdown_menu,
     wordcloud_chart,
 )
-from dr_streamlit.datarobot_branding import datarobot_logo
 
 deployment_id = os.getenv('deploymentid')
 project_id = os.getenv('projectid')
+logo_path = os.path.join(os.path.dirname(__file__), 'dr-logo.svg')
 
 
 def intro():
@@ -159,7 +160,7 @@ def main():
         if deployment_id:
             page_names_to_funcs["Predictor Demo"] = predictor_app
 
-        st.logo('./dr-logo.svg')
+        st.logo(logo_path)
         demo_name = st.sidebar.selectbox("Choose a demo", page_names_to_funcs.keys())
         page_names_to_funcs[demo_name]()
 

--- a/examples/prediction-demo/streamlit_app.py
+++ b/examples/prediction-demo/streamlit_app.py
@@ -159,10 +159,7 @@ def main():
         if deployment_id:
             page_names_to_funcs["Predictor Demo"] = predictor_app
 
-        st.sidebar.markdown(
-            datarobot_logo(),
-            unsafe_allow_html=True,
-        )
+        st.logo('./dr-logo.svg')
         demo_name = st.sidebar.selectbox("Choose a demo", page_names_to_funcs.keys())
         page_names_to_funcs[demo_name]()
 

--- a/setup.py
+++ b/setup.py
@@ -41,7 +41,7 @@ setup(
     url='https://github.com/datarobot/{}'.format(REPO_NAME),
     packages=find_packages(exclude=['examples']),
     package_dir={NAME: NAME},
-    python_requires='>=3.7',
+    python_requires='>=3.9',
     install_requires=install_requires,
     tests_require=tests_require,
     extras_require={'test': tests_require},
@@ -49,8 +49,6 @@ setup(
     classifiers=[
         'Programming Language :: Python',
         'Programming Language :: Python :: 3',
-        'Programming Language :: Python :: 3.7',
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/setup.py
+++ b/setup.py
@@ -25,12 +25,14 @@ tests_require = [
     'types-requests==2.28.11',
     'types-tabulate==0.9.0.20240106',
     'types-python-dateutil==2.8.19.20240106',
-    'streamlit == 1.35.0',
-    'datarobot == 3.4.0',
-    'plotly == 5.22',
-    'streamlit_wordcloud == 0.1.0',
+    'streamlit==1.40.0',
+    'datarobot==3.5.2',
+    'plotly==5.24.1',
     'kaleido==0.2.1',
-    'pillow==10.3.0',
+    'tabulate==0.9.0',
+    'altair==5.4.1',
+    'pillow==11.0.0',
+    'wordcloud>=1.9.4',
 ]
 
 setup(


### PR DESCRIPTION
This PR fixes a series of issues:

- Replace the outdated/unmaintained `streamlit-wordcloud` lib, using [wordcloud](https://pypi.org/project/wordcloud/) instead
- Update dependencies for example apps (Lets us get rid of the numpy 1.20 dep)
- Use latest DR logo in example app
- Fix cache issue with deployment vs deployment_id
- Remove mentions of the old Experimental execution env in favor of `[DataRobot] Python 3.12 Applications Base`

![image](https://github.com/user-attachments/assets/5618dd8b-44ae-4d35-9a1b-3f2e89379cb1)
