### PR TITLE
[APP-3651] Add apps CLI suport to building apps which run on `/`

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -177,6 +177,7 @@ def configure_custom_app_source_version(
     replicas: int,
     cpu_size: str,
     use_session_affinity: bool,
+    service_requests_on_root_path: bool,
 ) -> None:
     payload: Dict[str, Any] = {'baseEnvironmentVersionId': base_env_version_id}
     project_files = get_project_files_list(project)
@@ -217,6 +218,7 @@ def configure_custom_app_source_version(
             replicas=replicas,
             cpu_size=cpu_size,
             session_affinity=use_session_affinity,
+            service_requests_on_root_path=service_requests_on_root_path,
         )
         # Finally, add runtime params
         update_runtime_params(
@@ -238,6 +240,7 @@ def create_app_from_project(
     replicas: int,
     cpu_size: str,
     use_session_affinity: bool,
+    service_requests_on_root_path: bool,
 ) -> Dict[str, Any]:
     base_env_version_id = get_base_env_version(session, endpoint, base_env)
     source_name = f'{app_name}Source'
@@ -255,6 +258,7 @@ def create_app_from_project(
         replicas=replicas,
         cpu_size=cpu_size,
         use_session_affinity=use_session_affinity,
+        service_requests_on_root_path=service_requests_on_root_path,
     )
     app_payload = {'name': app_name, 'applicationSourceId': custom_app_source_id}
     click.echo(f'Starting {app_name} custom application.')
@@ -435,6 +439,12 @@ def parse_env_vars(ctx, param, value):
     default=False,
     help='Controls whether you want requests to go to the same instance when you have multiple replicas. This can be useful for the streamlit file upload widget, which can raise 401 errors without session stickiness or if you need to store persistent information in local memory/files.',
 )
+@click.option(
+    '--service-requests-on-root-path',
+    is_flag=True,
+    default=False,
+    help='If this flag is set then your app will service web requests + internal health checks on `/`, rather than servicing web requests on `/apps/id/ and health checks on `/apps/id`.',
+)
 @click.argument('application_name', type=click.STRING, required=True)
 def create(
     token: str,
@@ -449,6 +459,7 @@ def create(
     replicas: int,
     cpu_size: str,
     use_session_affinity: bool,
+    service_requests_on_root_path: bool,
 ) -> None:
     """
     Creates new custom application from docker image or base environment.
@@ -487,6 +498,7 @@ def create(
             replicas=replicas,
             cpu_size=cpu_size,
             use_session_affinity=use_session_affinity,
+            service_requests_on_root_path=service_requests_on_root_path,
         )
 
     if skip_wait or not app_data.get('statusUrl'):

--- a/drapps/helpers/custom_app_sources_functions.py
+++ b/drapps/helpers/custom_app_sources_functions.py
@@ -102,6 +102,7 @@ def update_resources(
     endpoint: str,
     source_id: str,
     version_id: str,
+    service_requests_on_root_path: bool,
     replicas: Optional[int] = None,
     cpu_size: Optional[str] = None,
     session_affinity: Optional[bool] = None,
@@ -117,8 +118,7 @@ def update_resources(
         resources["resourceLabel"] = f'cpu.{cpu_size}'  # type: ignore
     if session_affinity is not None:
         resources["sessionAffinity"] = session_affinity
-    if not resources:
-        return
+    resources["serviceWebRequestsOnRootPath"] = service_requests_on_root_path
     url = posixpath.join(endpoint, f"customApplicationSources/{source_id}/versions/{version_id}/")
     form_data = {"resources": (None, json.dumps(resources), 'application/json')}
     rsp = session.patch(url, files=form_data)

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -124,6 +124,7 @@ def test_create_from_docker_image(api_endpoint_env, api_token_env, wait_till_rea
 @pytest.mark.parametrize('use_session_affinity', (False, True))
 @pytest.mark.parametrize('n_instances', (2, None))  # None == unset
 @pytest.mark.parametrize('desired_cpu_size', ('2xsmall', None))
+@pytest.mark.parametrize('run_on_root', (True, False))
 def test_create_from_project(
     api_endpoint_env,
     api_token_env,
@@ -138,6 +139,7 @@ def test_create_from_project(
     use_session_affinity,
     n_instances,
     desired_cpu_size,
+    run_on_root,
 ):
     """
     Sort-of a mega test for the create app + src from a code-based project (non docker image). This tests:
@@ -268,6 +270,8 @@ def test_create_from_project(
     if desired_cpu_size:
         cli_parameters.append('--cpu-size')
         cli_parameters.append(desired_cpu_size)
+    if run_on_root:
+        cli_parameters.append('--service-requests-on-root-path')
 
     if not wait_till_ready:
         cli_parameters.append('--skip-wait')
@@ -332,6 +336,7 @@ def test_create_from_project(
     assert sent_payload.get('replicas') == n_instances or 1
     assert sent_payload.get("resourceLabel") == "cpu.nano" or 'cpu.small'
     assert sent_payload.get("sessionAffinity") == use_session_affinity
+    assert sent_payload.get("serviceWebRequestsOnRootPath") == run_on_root
 
 
 @pytest.mark.usefixtures('api_endpoint_env', 'api_token_env')


### PR DESCRIPTION
We have added support for making apps run on `/`. Currently they run on `/apps/id/<path>` , which corresponds to `/apps/id/<path>`, and need to have an exposed route on `/apps/id` for the K8s healthcheck API.

This PR adds that functionality to the apps CLI