### PR TITLE
[CIDG-1192] Don't wait forever for an execution env to be created

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -276,7 +276,9 @@ def wait_for_execution_environment_version_ready(
             progress.update(1)
             sleep(CHECK_STATUS_WAIT_TIME)
         else:
-            raise RuntimeError(f'Image build failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds')
+            raise RuntimeError(
+                f'Image build failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds'
+            )
     if img_status in IMAGE_BUILD_FAILED_STATUSES:
         raise Exception("Image build failed")
 

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -264,8 +264,9 @@ def create_app_from_project(
 def wait_for_execution_environment_version_ready(
     session: Session, endpoint: str, base_env_id: str, version_id: str
 ) -> None:
+    runs = 500
     with click.progressbar(iterable=repeat(0), label='Waiting till image is ready:') as progress:
-        while True:
+        for i in range(runs):
             response = get_execution_environment_version_by_id(
                 session=session, endpoint=endpoint, base_env_id=base_env_id, version_id=version_id
             )
@@ -274,6 +275,8 @@ def wait_for_execution_environment_version_ready(
                 break
             progress.update(1)
             sleep(CHECK_STATUS_WAIT_TIME)
+        else:
+            raise RuntimeError(f'Image build failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds')
     if img_status in IMAGE_BUILD_FAILED_STATUSES:
         raise Exception("Image build failed")
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 10.2.8
+version = 11.0.0


### PR DESCRIPTION
In the off-chance that we are having issues with the execution environment setup, we should make sure we don't wait forever for an env version to be created. 