### PR TITLE
[APP-3162] Fix drapps base requirements missing needed packages

### DIFF
--- a/.harness/on_pr_update/pipeline.yaml
+++ b/.harness/on_pr_update/pipeline.yaml
@@ -72,6 +72,39 @@ pipeline:
                           limits:
                             memory: 2Gi
                             cpu: "1"
+        - stage:
+            name: Test Base Environment
+            identifier: test_base_env
+            description: "Makes sure the dependencies that are specified in the base are enough to run the app"
+            type: CI
+            spec:
+              cloneCodebase: true
+              infrastructure:
+                type: KubernetesDirect
+                spec:
+                  connectorRef: account.cigeneral
+                  namespace: harness-delegate-ng
+                  automountServiceAccountToken: true
+                  nodeSelector: {}
+                  os: Linux
+              execution:
+                steps:
+                  - step:
+                      type: Run
+                      name: Run Unit Tests
+                      identifier: Tests
+                      spec:
+                        connectorRef: account.dockerhub_datarobot_read
+                        image: python:3.9
+                        shell: Sh
+                        command: |-
+                          set -x
+                          make req
+                          drapps
+                        resources:
+                          limits:
+                            memory: 2Gi
+                            cpu: "1"
   properties:
     ci:
       codebase:

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,10 @@ req-test:
 	pip install --upgrade pip==20.3.4
 	pip install -e .[test]
 
+req:
+	pip install --upgrade pip==20.3.4
+	pip install .
+
 test:
 	py.test -sv tests/ --log-cli-level=DEBUG
 	py.test -sv examples/prediction-demo/tests/ --log-cli-level=DEBUG

--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,7 @@ install_requires = [
     'requests-toolbelt==1.0.0',
     'tabulate==0.9.0',
     'pathspec==0.12.1',
+    'PyYAML==6.0.2'
 ]
 
 tests_require = [

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,7 @@ install_requires = [
     'requests>=2.28,<2.29',
     'requests-toolbelt==1.0.0',
     'tabulate==0.9.0',
+    'pathspec==0.12.1',
 ]
 
 tests_require = [


### PR DESCRIPTION
This PR does two things:
1. It adds needed dependencies to the drapps CLI package which were needed (in this case, pyYAML + pathspec). These likely slipped through the cracks because transitive dependencies in our test package worked. 
2. It adds a harness CI test to make sure we can run `drapps` and get a successful exit code. That way, if we have a missing dependency in the future, we'll know. 