### PR TITLE
[-] Replace `False` with `None` to make new versions of apps CLI work with 10.2.x

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -441,13 +441,13 @@ def parse_env_vars(ctx, param, value):
 @click.option(
     '--use-session-affinity',
     is_flag=True,
-    default=False,
+    default=None,
     help='Controls whether you want requests to go to the same instance when you have multiple replicas. This can be useful for the streamlit file upload widget, which can raise 401 errors without session stickiness or if you need to store persistent information in local memory/files.',
 )
 @click.option(
     '--service-requests-on-root-path',
     is_flag=True,
-    default=False,
+    default=None,
     help='If this flag is set then your app will service web requests + internal health checks on `/`, rather than servicing web requests on `/apps/id/ and health checks on `/apps/id`.',
 )
 @click.argument('application_name', type=click.STRING, required=True)

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -176,8 +176,8 @@ def configure_custom_app_source_version(
     runtime_params: List[Dict],
     replicas: int,
     cpu_size: str,
-    use_session_affinity: bool,
-    service_requests_on_root_path: bool,
+    use_session_affinity: Optional[bool],
+    service_requests_on_root_path: Optional[bool],
 ) -> None:
     payload: Dict[str, Any] = {'baseEnvironmentVersionId': base_env_version_id}
     project_files = get_project_files_list(project)
@@ -239,8 +239,8 @@ def create_app_from_project(
     runtime_params: List[Dict],
     replicas: int,
     cpu_size: str,
-    use_session_affinity: bool,
-    service_requests_on_root_path: bool,
+    use_session_affinity: Optional[bool],
+    service_requests_on_root_path: Optional[bool],
 ) -> Dict[str, Any]:
     base_env_version_id = get_base_env_version(session, endpoint, base_env)
     source_name = f'{app_name}Source'
@@ -463,8 +463,8 @@ def create(
     application_name: str,
     replicas: int,
     cpu_size: str,
-    use_session_affinity: bool,
-    service_requests_on_root_path: bool,
+    use_session_affinity: Optional[bool],
+    service_requests_on_root_path: Optional[bool],
 ) -> None:
     """
     Creates new custom application from docker image or base environment.

--- a/drapps/helpers/custom_app_sources_functions.py
+++ b/drapps/helpers/custom_app_sources_functions.py
@@ -102,7 +102,7 @@ def update_resources(
     endpoint: str,
     source_id: str,
     version_id: str,
-    service_requests_on_root_path: bool,
+    service_requests_on_root_path: Optional[bool] = None,
     replicas: Optional[int] = None,
     cpu_size: Optional[str] = None,
     session_affinity: Optional[bool] = None,
@@ -118,7 +118,8 @@ def update_resources(
         resources["resourceLabel"] = f'cpu.{cpu_size}'  # type: ignore
     if session_affinity is not None:
         resources["sessionAffinity"] = session_affinity
-    resources["serviceWebRequestsOnRootPath"] = service_requests_on_root_path
+    if service_requests_on_root_path is not None:
+        resources["serviceWebRequestsOnRootPath"] = service_requests_on_root_path
     url = posixpath.join(endpoint, f"customApplicationSources/{source_id}/versions/{version_id}/")
     form_data = {"resources": (None, json.dumps(resources), 'application/json')}
     rsp = session.patch(url, files=form_data)

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -121,10 +121,10 @@ def test_create_from_docker_image(api_endpoint_env, api_token_env, wait_till_rea
 @responses.activate
 @pytest.mark.parametrize('use_environment_id', (False, True))
 @pytest.mark.parametrize('wait_till_ready', (False, True))
-@pytest.mark.parametrize('use_session_affinity', (False, True, None))
+@pytest.mark.parametrize('use_session_affinity', (True, None))
 @pytest.mark.parametrize('n_instances', (2, None))  # None == unset
 @pytest.mark.parametrize('desired_cpu_size', ('2xsmall', None))
-@pytest.mark.parametrize('run_on_root', (True, False, None))
+@pytest.mark.parametrize('run_on_root', (True, None))
 def test_create_from_project(
     api_endpoint_env,
     api_token_env,
@@ -262,7 +262,7 @@ def test_create_from_project(
         '--cpu-size',
         desired_cpu_size,
     ]
-    if use_session_affinity is not None:
+    if use_session_affinity:
         cli_parameters.append('--use-session-affinity')
     if n_instances:
         cli_parameters.append('--replicas')
@@ -270,7 +270,7 @@ def test_create_from_project(
     if desired_cpu_size:
         cli_parameters.append('--cpu-size')
         cli_parameters.append(desired_cpu_size)
-    if run_on_root is not None :
+    if run_on_root:
         cli_parameters.append('--service-requests-on-root-path')
 
     if not wait_till_ready:

--- a/tests/cli/test_create.py
+++ b/tests/cli/test_create.py
@@ -121,10 +121,10 @@ def test_create_from_docker_image(api_endpoint_env, api_token_env, wait_till_rea
 @responses.activate
 @pytest.mark.parametrize('use_environment_id', (False, True))
 @pytest.mark.parametrize('wait_till_ready', (False, True))
-@pytest.mark.parametrize('use_session_affinity', (False, True))
+@pytest.mark.parametrize('use_session_affinity', (False, True, None))
 @pytest.mark.parametrize('n_instances', (2, None))  # None == unset
 @pytest.mark.parametrize('desired_cpu_size', ('2xsmall', None))
-@pytest.mark.parametrize('run_on_root', (True, False))
+@pytest.mark.parametrize('run_on_root', (True, False, None))
 def test_create_from_project(
     api_endpoint_env,
     api_token_env,
@@ -262,7 +262,7 @@ def test_create_from_project(
         '--cpu-size',
         desired_cpu_size,
     ]
-    if use_session_affinity:
+    if use_session_affinity is not None:
         cli_parameters.append('--use-session-affinity')
     if n_instances:
         cli_parameters.append('--replicas')
@@ -270,7 +270,7 @@ def test_create_from_project(
     if desired_cpu_size:
         cli_parameters.append('--cpu-size')
         cli_parameters.append(desired_cpu_size)
-    if run_on_root:
+    if run_on_root is not None :
         cli_parameters.append('--service-requests-on-root-path')
 
     if not wait_till_ready:
@@ -335,8 +335,14 @@ def test_create_from_project(
     )
     assert sent_payload.get('replicas') == n_instances or 1
     assert sent_payload.get("resourceLabel") == "cpu.nano" or 'cpu.small'
-    assert sent_payload.get("sessionAffinity") == use_session_affinity
-    assert sent_payload.get("serviceWebRequestsOnRootPath") == run_on_root
+    if use_session_affinity is not None:
+        assert sent_payload.get("sessionAffinity") == use_session_affinity
+    else:
+        assert 'sessionAffinity' not in sent_payload
+    if run_on_root is not None:
+        assert sent_payload.get("serviceWebRequestsOnRootPath") == run_on_root
+    else:
+        assert 'serviceWebRequestsOnRootPath' not in sent_payload
 
 
 @pytest.mark.usefixtures('api_endpoint_env', 'api_token_env')


### PR DESCRIPTION
Basically, when we use the latest version of the apps CLI and we send requests to old versions of DataRobot (eg an old 10.2 cluster) we get errors that `serviceWebRequestsOnRootPath` or `sessionAffinity` are not known resource keys as they are sent as `False`. 

While we *do* have a 10.2 branch, it's very likely that customers  are not going to point to our 10.2 branch, and instead `pip` install the latest, so we should clean up this point of friction before it causes an issue. It's also much more likely to cause issues for DataRobot developers who want to test against 10.2 to use the latest apps CLI. 