### PR TITLE
[-] Supply a better error message for Execution Environment Version failing to build

### DIFF
--- a/drapps/create.py
+++ b/drapps/create.py
@@ -281,10 +281,10 @@ def wait_for_execution_environment_version_ready(
             sleep(CHECK_STATUS_WAIT_TIME)
         else:
             raise RuntimeError(
-                f'Image build failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds'
+                f'Build for execution environment version failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds'
             )
     if img_status in IMAGE_BUILD_FAILED_STATUSES:
-        raise Exception("Image build failed")
+        raise Exception(f"Build for execution environment version failed with status {img_status}")
 
 
 def send_docker_image_with_progress(

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -42,6 +42,7 @@ from .helpers.execution_environments_functions import (
     create_execution_environment_version,
     get_execution_environment_by_id,
     get_execution_environment_by_name,
+    get_execution_environment_version_buildlog,
     get_execution_environment_version_by_id,
 )
 from .helpers.runtime_params_functions import verify_runtime_env_vars
@@ -280,11 +281,19 @@ def wait_for_execution_environment_version_ready(
             progress.update(1)
             sleep(CHECK_STATUS_WAIT_TIME)
         else:
+            build_log = get_execution_environment_version_buildlog(
+                session, endpoint, base_env_id, version_id
+            )
             raise RuntimeError(
-                f'Build for execution environment version with ID {version_id} timed out with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds.'
+                f'Build for execution environment version with ID {version_id} timed out with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds. \nThe error was: {build_log.error} \nThe build log: {build_log.log}'
             )
     if img_status in IMAGE_BUILD_FAILED_STATUSES:
-        raise Exception(f"Build for execution environment version with ID {version_id} failed.")
+        build_log = get_execution_environment_version_buildlog(
+            session, endpoint, base_env_id, version_id
+        )
+        raise Exception(
+            f"Build for execution environment version with ID {version_id} failed. \nThe error was: {build_log.error} \nThe build log: {build_log.log}"
+        )
 
 
 def send_docker_image_with_progress(

--- a/drapps/create.py
+++ b/drapps/create.py
@@ -281,10 +281,10 @@ def wait_for_execution_environment_version_ready(
             sleep(CHECK_STATUS_WAIT_TIME)
         else:
             raise RuntimeError(
-                f'Build for execution environment version failed with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds'
+                f'Build for execution environment version with ID {version_id} timed out with status {img_status} after {runs * CHECK_STATUS_WAIT_TIME} seconds.'
             )
     if img_status in IMAGE_BUILD_FAILED_STATUSES:
-        raise Exception(f"Build for execution environment version failed with status {img_status}")
+        raise Exception(f"Build for execution environment version with ID {version_id} failed.")
 
 
 def send_docker_image_with_progress(

--- a/drapps/helpers/execution_environments_functions.py
+++ b/drapps/helpers/execution_environments_functions.py
@@ -6,6 +6,7 @@
 #  Released under the terms of DataRobot Tool and Utility Agreement.
 #
 import posixpath
+from collections import namedtuple
 from typing import Any, Dict, List, Optional, Union
 
 from requests import Session
@@ -98,3 +99,18 @@ def get_execution_environment_version_by_id(
     response = session.get(url)
     handle_dr_response(response)
     return response.json()
+
+
+BuildLog = namedtuple('BuildLog', ['error', 'log'])
+
+
+def get_execution_environment_version_buildlog(
+    session: Session, endpoint, base_env_id: str, version_id: str
+) -> BuildLog:
+    url = posixpath.join(
+        endpoint, f"executionEnvironments/{base_env_id}/versions/{version_id}/buildLog/"
+    )
+    response = session.get(url)
+    handle_dr_response(response)
+    rsp_json = response.json()
+    return BuildLog(rsp_json['error'], rsp_json['log'])

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-version = 11.0.0
+version = 11.0.1


### PR DESCRIPTION
An error saying:
```
Image Build Failed
```
Doesn't mean anything. Customers don't know what `Image Build Failed` means, and there's no way to know if the Image Build Failed log means the image build for the app, the intermediate build for the app (in the case of a build-app.sh, or requirements.txt) , or the execution environment version.  I want to solve two problems with this:

1. We should make this error message understandable. Customers don't know what the `Image Build` really means, but they probably know what it means when their image build failed.
2. Getting logs, is *usually* a good way to get started at figuring out what's wrong.  The Apps team uses the apps CLI for testing environments, and this error will be useful to *us* so we imagine it's useful generally. 